### PR TITLE
ASE: randomhash: fix undefined behaviour in Pcg32Rng

### DIFF
--- a/ase/randomhash.hh
+++ b/ase/randomhash.hh
@@ -425,7 +425,7 @@ class Pcg32Rng {
   ror32 (const uint32_t bits, const uint32_t offset)
   {
     // bitwise rotate-right pattern recognized by gcc & clang iff 32==sizeof (bits)
-    return (bits >> offset) | (bits << (32 - offset));
+    return (bits >> offset) | (bits << ((32 - offset) & 31));
   }
   static inline constexpr uint32_t
   pcg_xsh_rr (const uint64_t input)


### PR DESCRIPTION
Left shifting a 32bit value by 32 bits is UB.