### PR TITLE
Support mute/solo/volume for tracks

### DIFF
--- a/ase/api.hh
+++ b/ase/api.hh
@@ -261,12 +261,6 @@ class Track : public virtual Device {
 public:
   virtual int32           midi_channel        () const = 0;          ///< Midi channel assigned to this track, 0 uses internal per-track channel.
   virtual void            midi_channel        (int32 midichannel) = 0;
-  virtual bool            mute                () const = 0;          ///< Whether the track is muted
-  virtual void            mute                (bool newmute) = 0;
-  virtual bool            solo                () const = 0;          ///< Whether the track is solo
-  virtual void            solo                (bool newsolo) = 0;
-  virtual double          volume              () const = 0;          ///< Volume of the track [0..1]
-  virtual void            volume              (double newvolume) = 0;
   virtual bool            is_master           () const = 0;          ///< Flag set on the main output track.
   virtual ClipS           launcher_clips      () = 0;                ///< Retrieve the list of clips that can be directly played.
   virtual DeviceP         access_device       () = 0;                ///< Retrieve Device handle for this track.

--- a/ase/api.hh
+++ b/ase/api.hh
@@ -261,6 +261,12 @@ class Track : public virtual Device {
 public:
   virtual int32           midi_channel        () const = 0;          ///< Midi channel assigned to this track, 0 uses internal per-track channel.
   virtual void            midi_channel        (int32 midichannel) = 0;
+  virtual bool            mute                () const = 0;          ///< Whether the track is muted
+  virtual void            mute                (bool newmute) = 0;
+  virtual bool            solo                () const = 0;          ///< Whether the track is solo
+  virtual void            solo                (bool newsolo) = 0;
+  virtual double          volume              () const = 0;          ///< Volume of the track [0..1]
+  virtual void            volume              (double newvolume) = 0;
   virtual bool            is_master           () const = 0;          ///< Flag set on the main output track.
   virtual ClipS           launcher_clips      () = 0;                ///< Retrieve the list of clips that can be directly played.
   virtual DeviceP         access_device       () = 0;                ///< Retrieve Device handle for this track.

--- a/ase/combo.cc
+++ b/ase/combo.cc
@@ -284,6 +284,15 @@ AudioChain::render (uint n_frames)
   // FIXME: assign obus if no children are present
 }
 
+std::string
+AudioChain::param_value_to_text (uint32_t paramid, double value) const
+{
+  if (paramid == VOLUME)
+    return string_format ("Volume %.1f dB", volume_db (value));
+  else
+    return AudioProcessor::param_value_to_text (paramid, value);
+}
+
 float
 AudioChain::volume_db (float volume)
 {

--- a/ase/combo.cc
+++ b/ase/combo.cc
@@ -288,7 +288,12 @@ std::string
 AudioChain::param_value_to_text (uint32_t paramid, double value) const
 {
   if (paramid == VOLUME)
-    return string_format ("Volume %.1f dB", volume_db (value));
+    {
+      if (value > 0)
+        return string_format ("Volume %.1f dB", volume_db (value));
+      else
+        return "Volume -\u221E dB";
+    }
   else
     return AudioProcessor::param_value_to_text (paramid, value);
 }

--- a/ase/combo.cc
+++ b/ase/combo.cc
@@ -169,14 +169,14 @@ AudioChain::initialize (SpeakerArrangement busses)
 
   ParameterMap pmap;
   pmap.group = "Settings";
-  pmap[VOLUME] = Param { "volume", _("Volume"), _("Volume"), default_volume, "", { 0, 1 } };
+  pmap[VOLUME] = Param { "volume", _("Volume"), _("Volume"), default_volume, "", { 0, 1 }, GUIONLY };
   pmap[MUTE]   = Param { "mute",   _("Mute"),   _("Mute"), false, "", {}, GUIONLY + ":toggle" };
 
   ChoiceS solo_state_cs;
   solo_state_cs += { "Off",   "Solo is turned off" };
   solo_state_cs += { "On",    "This track is solo" };
   solo_state_cs += { "Other", "Another track is solo" };
-  pmap[SOLO_STATE] = Param { "solo_state", _("Solo State"), _("Solo State"), 0, "", std::move (solo_state_cs) };
+  pmap[SOLO_STATE] = Param { "solo_state", _("Solo State"), _("Solo State"), 0, "", std::move (solo_state_cs), GUIONLY };
 
   install_params (pmap);
   prepare_event_input();

--- a/ase/combo.hh
+++ b/ase/combo.hh
@@ -3,6 +3,7 @@
 #define __ASE_COMBO_HH__
 
 #include <ase/processor.hh>
+#include <devices/blepsynth/linearsmooth.hh>
 
 namespace Ase {
 
@@ -29,6 +30,8 @@ class AudioChain : public AudioCombo {
   const SpeakerArrangement ospeakers_ = SpeakerArrangement (0);
   InletP           inlet_;
   AudioProcessor  *last_output_ = nullptr;
+  float            volume_ = 0;
+  LinearSmooth     volume_smooth_;
 protected:
   void     initialize        (SpeakerArrangement busses) override;
   void     reset             (uint64 target_stamp) override;
@@ -42,6 +45,8 @@ public:
   struct Probe { float dbspl = -192; };
   using ProbeArray = std::array<Probe,2>;
   ProbeArray* run_probes     (bool enable);
+  void        volume         (float new_volume);
+  static float volume_db     (float volume);
   static void static_info    (AudioProcessorInfo &info);
 private:
   ProbeArray *probes_ = nullptr;

--- a/ase/combo.hh
+++ b/ase/combo.hh
@@ -49,6 +49,7 @@ public:
   static void static_info    (AudioProcessorInfo &info);
   enum Params { VOLUME = 1, MUTE, SOLO_STATE };
   enum { SOLO_STATE_OFF, SOLO_STATE_ON, SOLO_STATE_OTHER };
+  std::string param_value_to_text (uint32_t paramid, double value) const override;
 private:
   ProbeArray *probes_ = nullptr;
   bool        probes_enabled_ = false;

--- a/ase/combo.hh
+++ b/ase/combo.hh
@@ -30,8 +30,9 @@ class AudioChain : public AudioCombo {
   const SpeakerArrangement ospeakers_ = SpeakerArrangement (0);
   InletP           inlet_;
   AudioProcessor  *last_output_ = nullptr;
-  float            volume_ = 0;
+  static float volume_db     (float volume);
   LinearSmooth     volume_smooth_;
+  bool             reset_volume_ = false;
 protected:
   void     initialize        (SpeakerArrangement busses) override;
   void     reset             (uint64 target_stamp) override;
@@ -45,9 +46,9 @@ public:
   struct Probe { float dbspl = -192; };
   using ProbeArray = std::array<Probe,2>;
   ProbeArray* run_probes     (bool enable);
-  void        volume         (float new_volume);
-  static float volume_db     (float volume);
   static void static_info    (AudioProcessorInfo &info);
+  enum Params { VOLUME = 1, MUTE, SOLO_STATE };
+  enum { SOLO_STATE_OFF, SOLO_STATE_ON, SOLO_STATE_OTHER };
 private:
   ProbeArray *probes_ = nullptr;
   bool        probes_enabled_ = false;

--- a/ase/properties.hh
+++ b/ase/properties.hh
@@ -61,7 +61,7 @@ class PropertyImpl : public ParameterProperty {
 public:
   ASE_DEFINE_MAKE_SHARED (PropertyImpl);
   Value   get_value () override                 { Value v; getter_ (v); return v; }
-  bool    set_value (const Value &v) override   { return setter_ (v); }
+  bool    set_value (const Value &v) override   { bool changed = setter_ (v); if (changed) emit_notify (ident()); return changed; }
   ChoiceS choices   () override                 { return lister_ ? lister_ (*this) : parameter_->choices(); }
 };
 

--- a/ase/track.cc
+++ b/ase/track.cc
@@ -77,6 +77,24 @@ TrackImpl::serialize (WritNode &xs)
     }
   // device chain
   xs["chain"] & *dynamic_cast<Serializable*> (&*chain_); // always exists
+  /* TODO: while other properties on the track are not suitable for automation,
+   * the following properies are; so we will need a different serialization
+   * strategy for these to once we support automation
+   */
+  for (auto prop : { "volume", "mute" })
+    {
+      if (xs.in_save())
+        {
+          Value v = get_value (prop);
+          xs[prop] & v;
+        }
+      if (xs.in_load())
+        {
+          Value v;
+          xs[prop] & v;
+          set_value (prop, v);
+        }
+    }
 }
 
 void

--- a/ase/track.cc
+++ b/ase/track.cc
@@ -138,7 +138,7 @@ TrackImpl::_activate ()
   DeviceImpl::_activate();
   midi_prod_->_activate();
   chain_->_activate();
-  set_chain_volumes();
+  set_solo_states();
 }
 
 void
@@ -191,13 +191,13 @@ bool
 TrackImpl::solo (bool new_solo)
 {
   solo_ = new_solo;
-  set_chain_volumes();
+  set_solo_states();
   emit_notify ("solo");
   return true;
 }
 
 void
-TrackImpl::set_chain_volumes()
+TrackImpl::set_solo_states()
 {
   Ase::Project *project = dynamic_cast<Ase::Project*> (_project());
   if (!project)

--- a/ase/track.cc
+++ b/ase/track.cc
@@ -190,6 +190,7 @@ TrackImpl::midi_channel (int32 midichannel) // TODO: implement
 bool
 TrackImpl::solo (bool new_solo)
 {
+  return_unless (new_solo != solo_, false);
   solo_ = new_solo;
   set_solo_states();
   emit_notify ("solo");

--- a/ase/track.hh
+++ b/ase/track.hh
@@ -11,9 +11,7 @@ class TrackImpl : public DeviceImpl, public virtual Track {
   DeviceP      chain_, midi_prod_;
   ClipImplS    clips_;
   uint         midi_channel_ = 0;
-  bool         mute_ = false;
   bool         solo_ = false;
-  double       volume_ = 0.5407418735601; // -10dB
   ASE_DEFINE_MAKE_SHARED (TrackImpl);
   friend class ProjectImpl;
   virtual         ~TrackImpl        ();
@@ -22,12 +20,8 @@ protected:
   String          fallback_name     () const override;
   void            serialize         (WritNode &xs) override;
   void            create_properties () override;
-  bool            mute              () const               { return mute_; }
-  bool            mute              (bool new_mute);
   bool            solo              () const               { return solo_; }
   bool            solo              (bool new_solo);
-  double          volume            () const               { return volume_; }
-  bool            volume            (double new_volume);
 public:
   class ClipScout;
   explicit        TrackImpl         (ProjectImpl&, bool masterflag);
@@ -43,6 +37,7 @@ public:
   void            midi_channel      (int32 midichannel) override;
   ClipS           launcher_clips    () override;
   DeviceP         access_device     () override;
+  PropertyS       access_properties () override;
   MonitorP        create_monitor    (int32 ochannel) override;
   void            update_clips      ();
   ssize_t         clip_index        (const ClipImpl &clip) const;

--- a/ase/track.hh
+++ b/ase/track.hh
@@ -15,7 +15,7 @@ class TrackImpl : public DeviceImpl, public virtual Track {
   ASE_DEFINE_MAKE_SHARED (TrackImpl);
   friend class ProjectImpl;
   virtual         ~TrackImpl        ();
-  void            set_chain_volumes ();
+  void            set_solo_states   ();
 protected:
   String          fallback_name     () const override;
   void            serialize         (WritNode &xs) override;

--- a/ase/track.hh
+++ b/ase/track.hh
@@ -11,9 +11,13 @@ class TrackImpl : public DeviceImpl, public virtual Track {
   DeviceP      chain_, midi_prod_;
   ClipImplS    clips_;
   uint         midi_channel_ = 0;
+  bool         mute_ = false;
+  bool         solo_ = false;
+  double       volume_ = 0.5407418735601; // -10dB
   ASE_DEFINE_MAKE_SHARED (TrackImpl);
   friend class ProjectImpl;
   virtual         ~TrackImpl        ();
+  void            set_chain_volumes ();
 protected:
   String          fallback_name     () const override;
   void            serialize         (WritNode &xs) override;
@@ -30,6 +34,12 @@ public:
   bool            is_master         () const override      { return MASTER_TRACK & gadget_flags(); }
   int32           midi_channel      () const override      { return midi_channel_; }
   void            midi_channel      (int32 midichannel) override;
+  bool            mute              () const override      { return mute_; }
+  void            mute              (bool new_mute) override;
+  bool            solo              () const override      { return solo_; }
+  void            solo              (bool new_solo) override;
+  double          volume            () const override      { return volume_; }
+  void            volume            (double new_volume) override;
   ClipS           launcher_clips    () override;
   DeviceP         access_device     () override;
   MonitorP        create_monitor    (int32 ochannel) override;

--- a/ase/track.hh
+++ b/ase/track.hh
@@ -21,6 +21,13 @@ class TrackImpl : public DeviceImpl, public virtual Track {
 protected:
   String          fallback_name     () const override;
   void            serialize         (WritNode &xs) override;
+  void            create_properties () override;
+  bool            mute              () const               { return mute_; }
+  bool            mute              (bool new_mute);
+  bool            solo              () const               { return solo_; }
+  bool            solo              (bool new_solo);
+  double          volume            () const               { return volume_; }
+  bool            volume            (double new_volume);
 public:
   class ClipScout;
   explicit        TrackImpl         (ProjectImpl&, bool masterflag);
@@ -34,12 +41,6 @@ public:
   bool            is_master         () const override      { return MASTER_TRACK & gadget_flags(); }
   int32           midi_channel      () const override      { return midi_channel_; }
   void            midi_channel      (int32 midichannel) override;
-  bool            mute              () const override      { return mute_; }
-  void            mute              (bool new_mute) override;
-  bool            solo              () const override      { return solo_; }
-  void            solo              (bool new_solo) override;
-  double          volume            () const override      { return volume_; }
-  void            volume            (double new_volume) override;
   ClipS           launcher_clips    () override;
   DeviceP         access_device     () override;
   MonitorP        create_monitor    (int32 ochannel) override;

--- a/ui/b/trackbutton.js
+++ b/ui/b/trackbutton.js
@@ -1,0 +1,77 @@
+// This Source Code Form is licensed MPL-2.0: http://mozilla.org/MPL/2.0
+// @ts-check
+
+import { LitComponent, html, JsExtract, live, docs, ref } from '../little.js';
+import * as Util from '../util.js';
+
+/** @class BTrackButton
+ * @description
+ * The <b-trackvolume> element is an editor for the track volume, implemented as thin wrapper
+ * arount <b-toggle>.
+ * ### Properties:
+ * *label*
+ * : Either "M" for mute property or "S" for solo property
+ * *track*
+ * : The track
+ * *value*
+ * : Current value
+ */
+
+// <STYLE/>
+JsExtract.scss`
+`;
+
+// <HTML/>
+const HTML = t => [
+html`
+<b-toggle label="${t.label}" .value="${t.value}" @valuechange="${event => t.set_value (event.target.value)}"></b-toggle>
+`
+];
+
+const OBJ_ATTRIBUTE = { type: Object, reflect: true };    // sync attribute with property
+const STRING_ATTRIBUTE = { type: String, reflect: true }; // sync attribute with property
+const BOOL_ATTRIBUTE = { type: Boolean, reflect: true }; // sync attribute with property
+
+// <SCRIPT/>
+class BTrackButton extends LitComponent {
+  createRenderRoot() { return this; }
+  render() { return HTML (this); }
+  static properties = {
+    track:      OBJ_ATTRIBUTE,
+    label:      STRING_ATTRIBUTE,
+    value:      BOOL_ATTRIBUTE
+  };
+  constructor() {
+    super();
+    this.label = "";
+    this.track = null;
+    this.prop = null;
+  }
+  set_value (value)
+  {
+    this.prop.set_value (value);
+  }
+  updated (changed_props)
+  {
+    this.update_value();
+  }
+  async update_value()
+  {
+    if (!this.prop)
+      {
+        let property;
+        if (this.label == "M")
+          property = "mute";
+        if (this.label == "S")
+          property = "solo";
+        let prop = await this.track.access_property (property);
+        this.prop = prop;
+        this.prop.on ("notify", args => {
+          if (args.detail == property)
+            this.update_value();
+        });
+      }
+    this.value = await this.prop.get_value();
+  }
+}
+customElements.define ('b-trackbutton', BTrackButton);

--- a/ui/b/trackview.js
+++ b/ui/b/trackview.js
@@ -81,8 +81,8 @@ const HTML = (t, d) => html`
         >${t.wtrack_.name}</b-editable>
     </span>
     <span class="-mute-solo">
-      <b-toggle @valuechange=${event => t.track.mute (event.target.value)} label="M"></b-toggle>
-      <b-toggle @valuechange=${event => t.track.solo (event.target.value)} label="S"></b-toggle>
+      <b-toggle @valuechange=${event => t.track.set_value ("mute", event.target.value)} label="M"></b-toggle>
+      <b-toggle @valuechange=${event => t.track.set_value ("solo", event.target.value)} label="S"></b-toggle>
       <b-trackvolume .track="${t.track}" @valuechange=${event => t.track.volume (event.target.value)}></b-trackvolume>
     </span>
     <div class="-lvm-main">

--- a/ui/b/trackview.js
+++ b/ui/b/trackview.js
@@ -61,6 +61,10 @@ b-trackview {
   .-track-name {
     display: inline-flex; position: relative; width: 7em; overflow: hidden;
   }
+  .-mute-solo {
+    display: flex;
+    flex-direction: row;
+  }
 }
 b-trackview[current-track] .b-trackview-control {
   background-color: zmod($b-button-border, Jz+=25%);
@@ -75,6 +79,11 @@ const HTML = (t, d) => html`
       <b-editable ${ref (h => t.trackname_ = h)} clicks="2" style="min-width: 4em; width: 100%"
         selectall @change=${event => t.track.name (event.detail.value.trim())}
         >${t.wtrack_.name}</b-editable>
+    </span>
+    <span class="-mute-solo">
+      <b-toggle @valuechange=${event => t.track.mute (event.target.value)} label="M"></b-toggle>
+      <b-toggle @valuechange=${event => t.track.solo (event.target.value)} label="S"></b-toggle>
+      <b-trackvolume .track="${t.track}" @valuechange=${event => t.track.volume (event.target.value)}></b-trackvolume>
     </span>
     <div class="-lvm-main">
       <div class="-lvm-levelbg" ${ref (h => t.levelbg_ = h)}></div>

--- a/ui/b/trackview.js
+++ b/ui/b/trackview.js
@@ -81,9 +81,9 @@ const HTML = (t, d) => html`
         >${t.wtrack_.name}</b-editable>
     </span>
     <span class="-mute-solo">
-      <b-toggle @valuechange=${event => t.track.set_value ("mute", event.target.value)} label="M"></b-toggle>
-      <b-toggle @valuechange=${event => t.track.set_value ("solo", event.target.value)} label="S"></b-toggle>
-      <b-trackvolume .track="${t.track}" @valuechange=${event => t.track.volume (event.target.value)}></b-trackvolume>
+      <b-trackbutton .track="${t.track}" label="M"></b-trackbutton>
+      <b-trackbutton .track="${t.track}" label="S"></b-trackbutton>
+      <b-trackvolume .track="${t.track}"></b-trackvolume>
     </span>
     <div class="-lvm-main">
       <div class="-lvm-levelbg" ${ref (h => t.levelbg_ = h)}></div>

--- a/ui/b/trackvolume.js
+++ b/ui/b/trackvolume.js
@@ -1,0 +1,248 @@
+// This Source Code Form is licensed MPL-2.0: http://mozilla.org/MPL/2.0
+// @ts-check
+
+import { LitComponent, html, JsExtract, live, docs, ref } from '../little.js';
+import * as Util from '../util.js';
+
+/** @class BTrackVolume
+ * @description
+ * The <b-trackvolume> element is an editor for that track volume
+ * The input `value` will be constrained to take on an amount between `min` and `max` inclusively.
+ * ### Properties:
+ * *value*
+ * : Contains the number being edited.
+ * *track*
+ * : The track
+ * ### Events:
+ * *valuechange*
+ * : Event emitted whenever the volume changes.
+ */
+
+// <STYLE/>
+JsExtract.scss`
+b-trackvolume {
+  display: flex; justify-content: flex-end;
+  .-trackvolume-bg {
+    background-color: rgba( 0, 0, 0, .80);
+    width: 10em;
+    height: 1em;
+    margin: 2px;
+  }
+  .-trackvolume-fg {
+    background-color: #999999;
+    height: 1em;
+  }
+}`;
+
+// <HTML/>
+const HTML = t => [
+html`
+<div class="-trackvolume-bg" @pointerdown="${t.pointerdown}">
+<div class="-trackvolume-fg" style="width: ${t.percent}%">
+</div>
+</div>
+`
+];
+
+const OBJ_ATTRIBUTE = { type: Object, reflect: true };    // sync attribute with property
+
+// <SCRIPT/>
+class BTrackVolume extends LitComponent {
+  createRenderRoot() { return this; }
+  render() { return HTML (this); }
+  static properties = {
+    track:      OBJ_ATTRIBUTE,
+    value:	{ type: Number },
+    percent:    { type: Number },
+  };
+  constructor() {
+    super();
+    this.value = 0;
+    this.percent = 0;
+    this.last_ = 0;
+    this.track = null;
+  }
+  updated (changed_props)
+  {
+    this.update_value();
+  }
+  async update_value()
+  {
+    this.value = await this.track.volume();
+    this.percent = this.value * 100;
+    this.last_ = this.value;
+  }
+  pointerdown (event)
+  {
+    spin_drag_start (this, event, this.drag_change.bind (this));
+  }
+  drag_change (distance)
+  {
+    this.last_ = Util.clamp (this.last_ + distance, 0, +1);
+    this.track.volume (this.last_);
+    this.value = this.last_;
+    this.percent = this.value * 100;
+  }
+}
+customElements.define ('b-trackvolume', BTrackVolume);
+
+const SPIN_DRAG = Symbol ('SpinDrag');
+const USE_PTRLOCK = true;
+
+/// Setup drag handlers for numeric spin button behavior.
+export function spin_drag_start (element, event, value_callback)
+{
+  console.assert (element instanceof Element);
+  console.assert (event.type === 'pointerdown');
+  // allow only primary button press (single click)
+  if (event.buttons != 1 || element[SPIN_DRAG])
+    {
+      if (element[SPIN_DRAG])
+	spin_drag_stop (element);
+      return false;
+    }
+  const spin_drag = {};
+  Object.assign (spin_drag, {
+    element,
+    value_callback,
+    pending_change: null,
+    captureid: undefined,
+    unlock_pointer: undefined,
+    stop_event: event => { event.preventDefault(); event.stopPropagation(); },
+    pointermove: spin_drag_pointermove.bind (spin_drag),
+    stop: spin_drag_stop.bind (spin_drag),
+    ptraccel: 1.0,
+    last: null,
+    drag: null,
+  });
+  // setup drag mode
+  try {
+    spin_drag.element.setPointerCapture (event.pointerId);
+    spin_drag.captureid = event.pointerId;
+  } catch (e) {
+    // something went wrong, bail out the drag
+    console.warn ('drag_start: error:', /**@type{Error}*/ (e).message);
+    return false;
+  }
+  // use pointer lock for knob turning
+  if (USE_PTRLOCK)
+    spin_drag.unlock_pointer = Util.request_pointer_lock (element);
+  const has_ptrlock = Util.has_pointer_lock (element);
+  spin_drag.last = { x: event.pageX, y: event.pageY };
+  spin_drag.drag = has_ptrlock ? { x: 0, y: 0 } : { x: event.pageX, y: event.pageY };
+  spin_drag.stop_event (event);
+  document.body.addEventListener ('wheel', spin_drag.stop_event, { capture: true, passive: false });
+  element.addEventListener ('pointermove', spin_drag.pointermove);
+  element.addEventListener ('pointerup', spin_drag.stop);
+  element[SPIN_DRAG] = spin_drag;
+  Shell.data_bubble.force (element);
+  return true; // spin drag started
+}
+
+/** Stop sping drag event handlers and pointer grab.
+ * @this{any}
+ */
+function spin_drag_stop (event_or_element= undefined)
+{
+  const spin_drag = event_or_element instanceof MouseEvent ? this : event_or_element[SPIN_DRAG];
+  if (!spin_drag?.stop)
+    return;
+  const element = spin_drag.element;
+  if (event_or_element instanceof MouseEvent)
+    spin_drag.stop_event (event_or_element);
+  element.removeEventListener ('pointerup', spin_drag.stop);
+  element.removeEventListener ('pointermove', spin_drag.pointermove);
+  document.body.removeEventListener ('wheel', spin_drag.stop_event, { capture: true, /*passive: false*/ });
+  // unset drag mode
+  spin_drag.unlock_pointer = spin_drag.unlock_pointer?.();
+  if (spin_drag.captureid !== undefined)
+    element.releasePointerCapture (spin_drag.captureid);
+  spin_drag.captureid = undefined;
+  spin_drag.pending_change = cancelAnimationFrame (spin_drag.pending_change);
+  spin_drag.last = null;
+  spin_drag.drag = null;
+  spin_drag.pointermove = null;
+  spin_drag.stop = null;
+  delete element[SPIN_DRAG];
+  Shell.data_bubble.unforce (element);
+}
+
+/** Handle sping drag pointer motion.
+ * @this{any}
+ */
+function spin_drag_pointermove (event)
+{
+  console.assert (event.type === 'pointermove');
+  const spin_drag = this, element = spin_drag.element;
+  if (!spin_drag.pending_change) // debounce value updates
+    spin_drag.pending_change = requestAnimationFrame (() => {
+      spin_drag.pending_change = null;
+      spin_drag_change.call (spin_drag);
+    });
+  const has_ptrlock = Util.has_pointer_lock (element);
+  if (has_ptrlock)
+    {
+      spin_drag.drag.x += event.movementX;
+      spin_drag.drag.y += event.movementY;
+    }
+  else
+    spin_drag.drag = { x: event.pageX, y: event.pageY };
+  spin_drag.ptraccel = spin_drag_granularity (event);
+  spin_drag.stop_event (event);
+}
+
+/** Turn accumulated spin drag motions into actual value changes.
+ * @this{any}
+ */
+function spin_drag_change ()
+{
+  const spin_drag = this, element = spin_drag.element;
+  const drag = spin_drag.drag, last = spin_drag.last;
+  const has_ptrlock = Util.has_pointer_lock (element);
+  const dx = (has_ptrlock ? drag.x : drag.x - last.x) * 0.5;
+  const dy =  has_ptrlock ? drag.y : drag.y - last.y;
+  let s = true;       // adjust via Increase and:
+  if (dy > 0)         // if DOWN
+    s = dx >= dy;     //   Decrease unless mostly RIGHT
+  else if (dx < 0)    // if LEFT
+    s = dy <= dx;     //   Decrease unless mostly UP
+  // reset drag accumulator
+  if (has_ptrlock)
+    spin_drag.drag = { x: 0, y: 0 };
+  else
+    spin_drag.last = { x: drag.x, y: drag.y };
+  // determine accumulated distance
+  let dist = (s ? +1 : -1) * Math.sqrt (dx * dx + dy * dy) * spin_drag.ptraccel;
+  // convert to physical pixel movements, so knob behaviour is unrelated to display resolution
+  if (!has_ptrlock ||
+      (has_ptrlock && CONFIG.dpr_movement))
+    {
+      const DPR = window.devicePixelRatio || 1;
+      dist *= DPR;
+    }
+  // assign value, stop dragging if return is true
+  if (spin_drag.value_callback (dist))
+    spin_drag_stop (element);
+}
+
+/// Calculate spin drag acceleration (slowdown) from event type and modifiers.
+function spin_drag_granularity (event)
+{
+  if (event.type == 'wheel') {
+    let gran = 0.025;                   // approximate wheel delta "step" to percent
+    if (event.shiftKey)
+      gran = 0.005;                     // slow down
+    else if (event.ctrlKey)
+      gran = 0.10;                      // speed up
+    return gran;
+  }
+  // pixel drag
+  const radius = 64;                    // assumed knob size
+  const circum = 2 * radius * Math.PI;
+  let gran = 1 / circum;                // steps per full turn to feel natural
+  if (event.shiftKey)
+    gran = gran * 0.1;                  // slow down
+  else if (event.ctrlKey)
+    gran = gran * 10;                   // speed up
+  return gran;
+}

--- a/ui/b/trackvolume.js
+++ b/ui/b/trackvolume.js
@@ -61,6 +61,7 @@ class BTrackVolume extends LitComponent {
     this.percent = 0;
     this.last_ = 0;
     this.track = null;
+    this.prop = null;
   }
   updated (changed_props)
   {
@@ -75,7 +76,12 @@ class BTrackVolume extends LitComponent {
   }
   async update_value()
   {
-    this.value = await this.track.volume();
+    if (!this.prop)
+      {
+        let prop = await this.track.access_property ("volume");
+        this.prop = prop;
+      }
+    this.value = await this.prop.get_normalized();
     this.percent = this.value * 100;
     this.last_ = this.value;
   }
@@ -86,9 +92,10 @@ class BTrackVolume extends LitComponent {
   drag_change (distance)
   {
     this.last_ = Util.clamp (this.last_ + distance, 0, +1);
-    this.track.volume (this.last_);
     this.value = this.last_;
     this.percent = this.value * 100;
+    if (this.prop)
+      this.prop.set_normalized (this.value);
   }
 }
 customElements.define ('b-trackvolume', BTrackVolume);

--- a/ui/b/trackvolume.js
+++ b/ui/b/trackvolume.js
@@ -66,13 +66,6 @@ class BTrackVolume extends LitComponent {
   updated (changed_props)
   {
     this.update_value();
-    var db_value = 20 * Math.log10 (2*this.value**3);
-    var db_string;
-    if (this.value === 0)
-      db_string = "-" + "\u221E";
-    else
-      db_string = db_value.toFixed (1);
-    this.setAttribute ('data-bubble', "Volume " + db_string + " dB");
   }
   async update_value()
   {
@@ -88,6 +81,7 @@ class BTrackVolume extends LitComponent {
     this.value = await this.prop.get_normalized();
     this.percent = this.value * 100;
     this.last_ = this.value;
+    this.setAttribute ('data-bubble', await this.prop.get_text());
   }
   pointerdown (event)
   {

--- a/ui/b/trackvolume.js
+++ b/ui/b/trackvolume.js
@@ -65,6 +65,13 @@ class BTrackVolume extends LitComponent {
   updated (changed_props)
   {
     this.update_value();
+    var db_value = 20 * Math.log10 (2*this.value**3);
+    var db_string;
+    if (this.value === 0)
+      db_string = "-" + "\u221E";
+    else
+      db_string = db_value.toFixed (1);
+    this.setAttribute ('data-bubble', "Volume " + db_string + " dB");
   }
   async update_value()
   {

--- a/ui/b/trackvolume.js
+++ b/ui/b/trackvolume.js
@@ -80,6 +80,10 @@ class BTrackVolume extends LitComponent {
       {
         let prop = await this.track.access_property ("volume");
         this.prop = prop;
+        this.prop.on ("notify", args => {
+          if (args.detail == "volume")
+            this.update_value();
+        });
       }
     this.value = await this.prop.get_normalized();
     this.percent = this.value * 100;


### PR DESCRIPTION
This is my first attempt to implement mute/solo/volume support for tracks.

*What is good:*
 - user can use volume slider, which has a good non-linear mapping to the track volume
 - user can toggle mute/solo to mute and solo tracks

*What is incomplete:*
 - the UI code doesn't pull the initial values from the track
 - the UI code doesn't display the new volume dB value if the volume is changed (could be a tooltip)
 - I wasn't able to do the slider properly, so right now I do some hacky stuff with numberinput.js to be able to display a slider without any number input; this should be conditional
- serialization isn't implemented (also see below)

*Other issues:*

Right now the mute/solo/volume interface between the UI and core is done by adding methods to the track. However, these values should support automation in the future. So these values really looks like 
AudioProcessor parameters. These have a minimum, maximum, default, non-linear mapping between UI values and actual DSP values, the ability to enter a value directly, and these are serialized automatically by the framework. However, as far as I can see Track is not an AudioProcessor, so I cannot make these parameters here.

Btw, panning isn't implemented yet because we don't have a mixer view, it should be added once we have that.