### PR TITLE
Update event processing code in BlepSynth for sample accurate event processing

### DIFF
--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -409,15 +409,19 @@ class BlepSynth : public AudioProcessor {
       const uint I = oscnum + 1;
       const uint O = oscnum * (OSC2_SHAPE - OSC1_SHAPE);
       const String o = string_format ("osc_%u_", I);
+
+      const double shape_default  = oscnum ? -100 : 0;
+      const double octave_default = oscnum;
+
       pmap.group = _("Oscillator %u", I);
-      pmap[O+OSC1_SHAPE]       = Param { o+"shape",       _("Osc %u Shape", I),             _("Shp%u", I),  0, "%", { -100, 100, }, };
+      pmap[O+OSC1_SHAPE]       = Param { o+"shape",       _("Osc %u Shape", I),             _("Shp%u", I),  shape_default, "%", { -100, 100, }, };
       pmap[O+OSC1_PULSE_WIDTH] = Param { o+"pulse_width", _("Osc %u Pulse Width", I),       _("PW%u", I),  50, "%", { 0, 100, }, };
       pmap[O+OSC1_SUB]         = Param { o+"subharmonic", _("Osc %u Subharmonic", I),       _("Sub%u", I),  0, "%", { 0, 100, }, };
       pmap[O+OSC1_SUB_WIDTH]   = Param { o+"subharmonic_width", _("Osc %u Subharmonic Width", I), _("SbW%u", I), 50, "%", { 0, 100, }, };
       pmap[O+OSC1_SYNC]        = Param { o+"sync_slave",  _("Osc %u Sync Slave", I),        _("Syn%u", I),  0, "Semitones", { 0, 60, }, };
 
-      pmap[O+OSC1_PITCH]  = Param { o+"pitch",  _("Osc %u Pitch", I),  _("Pit%u", I), 0, "semitones", { -7, 7, }, };
-      pmap[O+OSC1_OCTAVE] = Param { o+"octave", _("Osc %u Octave", I), _("Oct%u", I), 0, "octaves",   { -2, 3, }, };
+      pmap[O+OSC1_PITCH]  = Param { o+"pitch",  _("Osc %u Pitch", I),  _("Pit%u", I), 0,              "semitones", { -7, 7, }, };
+      pmap[O+OSC1_OCTAVE] = Param { o+"octave", _("Osc %u Octave", I), _("Oct%u", I), octave_default, "octaves",   { -2, 3, }, };
 
       /* TODO: unison_voices property should have stepping set to 1 */
       pmap[O+OSC1_UNISON_VOICES] = Param { o+"unison_voices", _("Osc %u Unison Voices", I), _("Voi%u", I), 1, "Voices", { 1, 16, }, };
@@ -428,7 +432,7 @@ class BlepSynth : public AudioProcessor {
     oscparams (0);
 
     pmap.group = _("Mix");
-    pmap[MIX]       = Param { "mix", _("Mix"), _("Mix"), 0, "%", { 0, 100 }, };
+    pmap[MIX]       = Param { "mix", _("Mix"), _("Mix"), 30, "%", { 0, 100 }, };
     pmap[VEL_TRACK] = Param { "vel_track", _("Velocity Tracking"), _("VelTr"), 50, "%", { 0, 100, }, };
     // TODO: post_gain probably should default to 0dB once we have track/mixer volumes
     pmap[POST_GAIN] = Param { "post_gain", _("Post Gain"), _("Gain"), -12, "dB", { -24, 24, }, };

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -996,9 +996,11 @@ class BlepSynth : public AudioProcessor {
     MidiEventInput evinput = midi_event_input();
     for (const auto &ev : evinput)
       {
+        uint frame = std::max<int> (ev.frame, 0); // TODO: should be unsigned anyway, issue #26
+
         // process any audio that is before the event
-        render_audio (left_out + offset, right_out + offset, ev.frame - offset);
-        offset = ev.frame;
+        render_audio (left_out + offset, right_out + offset, frame - offset);
+        offset = frame;
 
         switch (ev.message())
           {

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -996,8 +996,6 @@ class BlepSynth : public AudioProcessor {
     MidiEventInput evinput = midi_event_input();
     for (const auto &ev : evinput)
       {
-        assert_return (ev.frame >= 0); // TODO: should be unsigned anyway, issue #26
-
         // process any audio that is before the event
         render_audio (left_out + offset, right_out + offset, ev.frame - offset);
         offset = ev.frame;

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -596,6 +596,8 @@ class BlepSynth : public AudioProcessor {
                       voice->skfilter_.reset();
                   }
               }
+            set_parameter_used (LADDER_MODE, filter_type_ == FILTER_TYPE_LADDER);
+            set_parameter_used (SKFILTER_MODE, filter_type_ == FILTER_TYPE_SKFILTER);
           }
           break;
         case ATTACK:
@@ -645,6 +647,9 @@ class BlepSynth : public AudioProcessor {
     int unison_voices = irintf (get_param (O+OSC1_UNISON_VOICES));
     unison_voices = CLAMP (unison_voices, 1, 16);
     osc.set_unison (unison_voices, get_param (O+OSC1_UNISON_DETUNE), get_param (O+OSC1_UNISON_STEREO) * 0.01);
+
+    set_parameter_used (O + OSC1_UNISON_DETUNE, unison_voices > 1);
+    set_parameter_used (O + OSC1_UNISON_STEREO, unison_voices > 1);
   }
   static double
   perc_to_s (double perc)

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -994,22 +994,9 @@ class BlepSynth : public AudioProcessor {
       {
         assert_return (ev.frame >= 0); // TODO: should be unsigned anyway, issue #26
 
-        // ensure that new offset from event is not larger than n_frames
-        uint new_offset = ev.frame;
-        if (new_offset > n_frames)
-          {
-            printerr ("*** BlepSynth: event offset is after end of block (new_offset = %d, n_frrames = %d)\n", new_offset, n_frames);
-            new_offset = n_frames;
-          }
-        // ensure that new offset is after last event
-        if (new_offset < offset)
-          {
-            printerr ("*** BlepSynth: events not sorted (event new_offset = %d less than offset = %d)\n", new_offset, offset);
-            new_offset = offset;
-          }
         // process any audio that is before the event
-        render_audio (left_out + offset, right_out + offset, new_offset - offset);
-        offset = new_offset;
+        render_audio (left_out + offset, right_out + offset, ev.frame - offset);
+        offset = ev.frame;
 
         switch (ev.message())
           {

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -580,37 +580,52 @@ class BlepSynth : public AudioProcessor {
   void
   adjust_param (uint32_t tag) override
   {
-    if (tag == FILTER_TYPE)
+    switch (tag)
       {
-        int new_filter_type = irintf (get_param (FILTER_TYPE));
-        if (new_filter_type != filter_type_)
+        case FILTER_TYPE:
           {
-            filter_type_ = new_filter_type;
-            for (Voice *voice : active_voices_)
+            int new_filter_type = irintf (get_param (FILTER_TYPE));
+            if (new_filter_type != filter_type_)
               {
-                if (filter_type_ == FILTER_TYPE_LADDER)
-                  voice->ladder_filter_.reset();
-                if (filter_type_ == FILTER_TYPE_SKFILTER)
-                  voice->skfilter_.reset();
+                filter_type_ = new_filter_type;
+                for (Voice *voice : active_voices_)
+                  {
+                    if (filter_type_ == FILTER_TYPE_LADDER)
+                      voice->ladder_filter_.reset();
+                    if (filter_type_ == FILTER_TYPE_SKFILTER)
+                      voice->skfilter_.reset();
+                  }
               }
           }
-      }
-    if (tag == ATTACK || tag == DECAY || tag == SUSTAIN || tag == RELEASE ||
-        tag == ATTACK_SLOPE || tag == DECAY_SLOPE || tag == RELEASE_SLOPE)
-      {
-        need_update_volume_envelope_ = true;
-      }
-    if (tag == FIL_ATTACK || tag == FIL_DECAY || tag == FIL_SUSTAIN || tag == FIL_RELEASE)
-      {
-        need_update_filter_envelope_ = true;
-      }
-    if (tag == VE_MODEL)
-      {
-        bool ve_has_slope = irintf (get_param (VE_MODEL)) > 0; // exponential envelope has no slope parameters
+          break;
+        case ATTACK:
+        case DECAY:
+        case SUSTAIN:
+        case RELEASE:
+        case ATTACK_SLOPE:
+        case DECAY_SLOPE:
+        case RELEASE_SLOPE:
+          {
+            need_update_volume_envelope_ = true;
+            break;
+          }
+        case FIL_ATTACK:
+        case FIL_DECAY:
+        case FIL_SUSTAIN:
+        case FIL_RELEASE:
+          {
+            need_update_filter_envelope_ = true;
+            break;
+          }
+        case VE_MODEL:
+          {
+            bool ve_has_slope = irintf (get_param (VE_MODEL)) > 0; // exponential envelope has no slope parameters
 
-        set_parameter_used (ATTACK_SLOPE,  ve_has_slope);
-        set_parameter_used (DECAY_SLOPE,   ve_has_slope);
-        set_parameter_used (RELEASE_SLOPE, ve_has_slope);
+            set_parameter_used (ATTACK_SLOPE,  ve_has_slope);
+            set_parameter_used (DECAY_SLOPE,   ve_has_slope);
+            set_parameter_used (RELEASE_SLOPE, ve_has_slope);
+            break;
+          }
       }
   }
   void


### PR DESCRIPTION
Since we now have sample accurate parameter updates (in addition to sample accurate midi events), I updated the blepsyntht code to handle this by processing events between audio rendering where appropriate. This branch also checks the ordering of the event stream and prints errors to stderr if the order of the events is invalid. This currently happens for my version of Anklang, and needs to be fixed elsewhere.