### PR TITLE
Midi events uint offset

### DIFF
--- a/ase/clapplugin.cc
+++ b/ase/clapplugin.cc
@@ -555,21 +555,21 @@ ClapAudioProcessor::convert_clap_events (const clap_process_t &process, const bo
       case MidiMessage::NOTE_OFF:
       case MidiMessage::AFTERTOUCH:
         if (as_clapnotes && ev.type == MidiEvent::AFTERTOUCH) {
-          expr = setup_expression (&input_events_[j++], MAX (ev.frame, 0), 0);
+          expr = setup_expression (&input_events_[j++], ev.frame, 0);
           expr->expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
           expr->note_id = ev.noteid;
           expr->channel = ev.channel;
           expr->key = ev.key;
           expr->value = ev.velocity;
         } else if (as_clapnotes) {
-          evnote = setup_evnote (&input_events_[j++], MAX (ev.frame, 0), 0);
+          evnote = setup_evnote (&input_events_[j++], ev.frame, 0);
           evnote->header.type = ev.type == MidiEvent::NOTE_ON ? CLAP_EVENT_NOTE_ON : CLAP_EVENT_NOTE_OFF;
           evnote->note_id = ev.noteid;
           evnote->channel = ev.channel;
           evnote->key = ev.key;
           evnote->velocity = ev.velocity;
         } else {
-          midi1 = setup_midi1 (&input_events_[j++], MAX (ev.frame, 0), 0);
+          midi1 = setup_midi1 (&input_events_[j++], ev.frame, 0);
           midi1->data[0] = uint8_t (ev.type) | (ev.channel & 0xf);
           midi1->data[1] = ev.key;
           midi1->data[2] = std::min (uint8_t (ev.velocity * 127), uint8_t (127));
@@ -577,33 +577,33 @@ ClapAudioProcessor::convert_clap_events (const clap_process_t &process, const bo
         break;
       case MidiMessage::ALL_NOTES_OFF:
         if (as_clapnotes) {
-          evnote = setup_evnote (&input_events_[j++], MAX (ev.frame, 0), 0);
+          evnote = setup_evnote (&input_events_[j++], ev.frame, 0);
           evnote->header.type = CLAP_EVENT_NOTE_CHOKE;
           evnote->note_id = -1;
           evnote->channel = -1;
           evnote->key = -1;
           evnote->velocity = 0;
         } else {
-          midi1 = setup_midi1 (&input_events_[j++], MAX (ev.frame, 0), 0);
+          midi1 = setup_midi1 (&input_events_[j++], ev.frame, 0);
           midi1->data[0] = 0xB0 | (ev.channel & 0xf);
           midi1->data[1] = 123;
           midi1->data[2] = 0;
         }
         break;
       case MidiMessage::CONTROL_CHANGE:
-        midi1 = setup_midi1 (&input_events_[j++], MAX (ev.frame, 0), 0);
+        midi1 = setup_midi1 (&input_events_[j++], ev.frame, 0);
         midi1->data[0] = 0xB0 | (ev.channel & 0xf);
         midi1->data[1] = ev.param;
         midi1->data[2] = ev.cval;
         break;
       case MidiMessage::CHANNEL_PRESSURE:
-        midi1 = setup_midi1 (&input_events_[j++], MAX (ev.frame, 0), 0);
+        midi1 = setup_midi1 (&input_events_[j++], ev.frame, 0);
         midi1->data[0] = 0xD0 | (ev.channel & 0xf);
         midi1->data[1] = std::min (uint8_t (ev.velocity * 127), uint8_t (127));
         midi1->data[2] = 0;
         break;
       case MidiMessage::PITCH_BEND:
-        midi1 = setup_midi1 (&input_events_[j++], MAX (ev.frame, 0), 0);
+        midi1 = setup_midi1 (&input_events_[j++], ev.frame, 0);
         midi1->data[0] = 0xE0 | (ev.channel & 0xf);
         midi1->data[1] = std::min (uint8_t (ev.velocity * 127), uint8_t (127));
         midi1->data[2] = 0;

--- a/ase/midievent.hh
+++ b/ase/midievent.hh
@@ -49,8 +49,8 @@ enum class MidiMessage : int32_t {
 /// MidiEvent data structure.
 struct MidiEvent {
   using enum MidiEventType;
-  static_assert (AUDIO_BLOCK_MAX_RENDER_SIZE <= 2048); // -2048…+2047 fits frame
-  int       frame : 12;  ///< Offset into current block, delayed if negative
+  static_assert (AUDIO_BLOCK_MAX_RENDER_SIZE <= 4096); // 0…+4095 fits frame
+  uint      frame : 12;  ///< Offset into current block, delayed if negative
   uint      channel : 4; ///< 0…15 for standard events
   MidiEventType type;    ///< MidiEvent type, one of the MidiEventType members
   union {

--- a/ase/midievent.hh
+++ b/ase/midievent.hh
@@ -118,7 +118,7 @@ class MidiEventReader : QueueMultiplexer<MAXQUEUES,std::vector<MidiEvent>::const
   using Base = QueueMultiplexer<MAXQUEUES,std::vector<MidiEvent>::const_iterator>;
   ASE_CLASS_NON_COPYABLE (MidiEventReader);
 public:
-  using iterator = Base::iterator;
+  using iterator = typename Base::iterator;
   using Base::assign;
   size_t   events_pending  () const { return this->count_pending(); }
   iterator begin           ()       { return this->Base::begin(); }

--- a/ase/midilib.cc
+++ b/ase/midilib.cc
@@ -146,7 +146,7 @@ public:
         TickEvent tnote = future_stack.back();
         future_stack.pop_back();
         const int64 frame = transport.sample_from_tick (tnote.tick - begin_tick);
-        assert_paranoid (frame >= -2048 && frame <= 2047);
+        assert_paranoid (frame >= 0 && frame <= 4095);
         MDEBUG ("POP: t=%d ev=%s f=%d\n", tnote.tick, tnote.event.to_string(), frame);
         evout.append_unsorted (frame, tnote.event);
       }
@@ -171,7 +171,7 @@ public:
               if (etick < end_tick)
                 {
                   const int64 frame = transport.sample_from_tick (etick - begin_tick);
-                  assert_paranoid (frame >= -2048 && frame <= 2047);
+                  assert_paranoid (frame >= 0 && frame <= 4095);
                   // interleave with earlier MIDI through events
                   evout.append_unsorted (frame, event);
                   MDEBUG ("NOW: t=%d ev=%s f=%d\n", etick, event.to_string(), frame);

--- a/devices/blepsynth/blepsynth.cc
+++ b/devices/blepsynth/blepsynth.cc
@@ -996,11 +996,9 @@ class BlepSynth : public AudioProcessor {
     MidiEventInput evinput = midi_event_input();
     for (const auto &ev : evinput)
       {
-        uint frame = std::max<int> (ev.frame, 0); // TODO: should be unsigned anyway, issue #26
-
         // process any audio that is before the event
-        render_audio (left_out + offset, right_out + offset, frame - offset);
-        offset = frame;
+        render_audio (left_out + offset, right_out + offset, ev.frame - offset);
+        offset = ev.frame;
 
         switch (ev.message())
           {

--- a/devices/liquidsfz/liquidsfz.cc
+++ b/devices/liquidsfz/liquidsfz.cc
@@ -35,10 +35,9 @@ class LiquidSFZLoader
           {
             if (want_sfz_ != have_sfz_)
               {
-                printf ("LiquidSFZ: loading %s...", want_sfz_.c_str());
-                fflush (stdout);
+                printerr ("LiquidSFZ: loading %s...", want_sfz_.c_str());
                 bool result = synth_.load (want_sfz_);
-                printf ("%s\n", result ? "OK" : "FAIL");
+                printerr ("%s\n", result ? "OK" : "FAIL");
                 // TODO: handle load error
 
                 have_sfz_ = want_sfz_;
@@ -51,7 +50,7 @@ class LiquidSFZLoader
             state_.store (STATE_IDLE);
           }
       }
-    printf ("run() done\n");
+    printerr ("LiquidSFZ: run() done\n");
   }
 public:
   LiquidSFZLoader (Synth &synth) :
@@ -59,14 +58,14 @@ public:
   {
     thread_ = std::thread (&LiquidSFZLoader::run, this);
     want_sfz_.reserve (4096); // avoid allocations in audio thread
-    printf ("LiquidSFZLoader()\n");
+    printerr ("LiquidSFZLoader()\n");
   }
   ~LiquidSFZLoader()
   {
     quit_.store (1);
     sem_.post();
     thread_.join();
-    printf ("~LiquidSFZLoader()\n");
+    printerr ("~LiquidSFZLoader()\n");
   }
   // called from audio thread
   bool

--- a/devices/liquidsfz/liquidsfz.cc
+++ b/devices/liquidsfz/liquidsfz.cc
@@ -182,14 +182,13 @@ class LiquidSFZ : public AudioProcessor {
         MidiEventInput evinput = midi_event_input();
         for (const auto &ev : evinput)
           {
-            const int time_stamp = std::max<int> (ev.frame, 0);
             switch (ev.message())
               {
               case MidiMessage::NOTE_OFF:
-                synth_.add_event_note_off (time_stamp, ev.channel, ev.key);
+                synth_.add_event_note_off (ev.frame, ev.channel, ev.key);
                 break;
               case MidiMessage::NOTE_ON:
-                synth_.add_event_note_on (time_stamp, ev.channel, ev.key, std::clamp (irintf (ev.velocity * 127), 0, 127));
+                synth_.add_event_note_on (ev.frame, ev.channel, ev.key, std::clamp (irintf (ev.velocity * 127), 0, 127));
                 break;
               case MidiMessage::ALL_NOTES_OFF:
               case MidiMessage::ALL_SOUND_OFF:

--- a/devices/saturation/saturation.cc
+++ b/devices/saturation/saturation.cc
@@ -91,11 +91,9 @@ public:
     MidiEventInput evinput = midi_event_input();
     for (const auto &ev : evinput)
       {
-        uint frame = std::max<int> (ev.frame, 0); // TODO: should be unsigned anyway, issue #26
-
         // process any audio that is before the event
-        render_audio (left_in + offset, right_in + offset, left_out + offset, right_out + offset, frame - offset);
-        offset = frame;
+        render_audio (left_in + offset, right_in + offset, left_out + offset, right_out + offset, ev.frame - offset);
+        offset = ev.frame;
 
         switch (ev.message())
           {


### PR DESCRIPTION
As discussed in #26, midi events should not contain negative frame offsets. Here is a PR for that.

- I didn't change `AUDIO_BLOCK_MAX_RENDER_SIZE` as I'm not sure if that depends on anything else (and 2048 is certainly enough for all use cases I can think of), but in principle we now support frame offsets up to 4095.
- micro-timing information provided by the alsa driver is discarded now, but we can look into this once we really implement recording
