### PR TITLE
Default tempo 120 bpm

### DIFF
--- a/ase/project.cc
+++ b/ase/project.cc
@@ -59,7 +59,7 @@ ProjectImpl::ProjectImpl()
 {
   if (tracks_.empty())
     create_track (); // ensure Master track
-  tick_sig_.set_bpm (90);
+  tick_sig_.set_bpm (120);
 
   if (0)
     autoplay_timer_ = main_loop->exec_timer ([this] () {
@@ -813,7 +813,7 @@ ProjectImpl::create_properties ()
   bag.group = _("Timing");
   bag += Prop (getbpb, setbpb, { "numerator", _("Signature Numerator"), _("Numerator"), 4., "", MinMaxStep { 1., 63., 0 }, STANDARD });
   bag += Prop (getunt, setunt, { "denominator", _("Signature Denominator"), _("Denominator"), 4, "", MinMaxStep { 1, 16, 0 }, STANDARD });
-  bag += Prop (getbpm, setbpm, { "bpm", _("Beats Per Minute"), _("BPM"), 90., "", MinMaxStep { 10., 1776., 0 }, STANDARD });
+  bag += Prop (getbpm, setbpm, { "bpm", _("Beats Per Minute"), _("BPM"), 120., "", MinMaxStep { 10., 1776., 0 }, STANDARD });
   bag.group = _("Tuning");
   bag += Prop (make_enum_getter<MusicalTuning> (&musical_tuning_), make_enum_setter<MusicalTuning> (&musical_tuning_),
                { "musical_tuning", _("Musical Tuning"), _("Tuning"), uint32_t (MusicalTuning::OD_12_TET), "", {}, STANDARD, {

--- a/ase/project.cc
+++ b/ase/project.cc
@@ -697,12 +697,14 @@ ProjectImpl::start_playback (double autostop)
   std::shared_ptr<CallbackS> queuep = std::make_shared<CallbackS>();
   for (auto track : tracks_)
     track->queue_cmd (*queuep, track->START);
-  auto job = [proc, queuep, autostop] () {
+  const TickSignature tsig (tick_sig_);
+  auto job = [proc, queuep, tsig, autostop] () {
     AudioEngine &engine = proc->engine();
     const double udmax = 18446744073709549568.0; // max double exactly matching an uint64_t
     const uint64_t s = autostop > udmax ? udmax : autostop * engine.sample_rate();
     engine.set_autostop (s);
     AudioTransport &transport = const_cast<AudioTransport&> (engine.transport());
+    transport.tempo (tsig);
     transport.running (true);
     for (const auto &cmd : *queuep)
       cmd();


### PR DESCRIPTION
### Discussion

Whenever I start Anklang and enter some notes, I have to adjust the tempo. 90bpm (our current default) is simply too slow for my taste. Also, other DAWs don't use that tempo. Here is a list with a few examples:

- Ardour: 120 bpm
- Reaper: 120 bpm
- FL Studio: 140 bpm
- Bitwig: 110 bpm
- Ableton Live: 120 bpm
- Hydrogen: 120 bpm

So I think 120 bpm would be a good default. It also shows up if you google for the topic. Of course if we had a functionality to automatically load a template project once you start Anklang, users could customize the template with any bpm they want to use.

### Implementation

I noticed that just changing the bpm in `ase/project.cc` is not enough, simply because it is never propagated to the engine transport. So apart from changing the tempo the branch contains a commit (https://github.com/tim-janik/anklang/commit/a7f6dc89d4f7e807a984cdcf519fea98656f3b02) to automatically update the engine transport with the current tick signature whenever the user presses play. Once we support tempo automation on the master track we'll need that update anyway, because then the initial tempo depends on the song position pointer.