### PR TITLE
Piano roll fixes

### DIFF
--- a/ui/b/piano-ctrl.js
+++ b/ui/b/piano-ctrl.js
@@ -176,10 +176,11 @@ export class PianoCtrl {
 	};
 	await queue_modify_notes (clip, notes_shift, "Shift Left");
 	break; }
-      case UP: { // ↑
+      case UP: case SHIFT + UP: { // ↑
+	const semitones = (key_ctrl_alt_shift & SHIFT) ? 12 : 1;
 	let bounced = false;
 	const note_mods = note => {
-	  const newkey = note.key + 1;
+	  const newkey = note.key + semitones;
 	  bounced |= newkey >= 128;
 	  return { key: newkey };
 	};
@@ -187,10 +188,11 @@ export class PianoCtrl {
 	  notes_filter_modify (allnotes, note => note.selected, note_mods, () => !bounced);
 	await queue_modify_notes (clip, notes_shift, "Shift Up");
 	break; }
-      case DOWN: { // ↓
+      case DOWN: case SHIFT + DOWN: { // ↓
+	const semitones = (key_ctrl_alt_shift & SHIFT) ? 12 : 1;
 	let bounced = false;
 	const note_mods = note => {
-	  const newkey = note.key - 1;
+	  const newkey = note.key - semitones;
 	  bounced |= newkey < 0;
 	  return { key: newkey };
 	};

--- a/ui/b/pianoroll.js
+++ b/ui/b/pianoroll.js
@@ -734,22 +734,30 @@ function paint_notes()
   ctx.fillStyle = note_color;
   ctx.strokeStyle = csp ('--piano-roll-note-focus-border');
   // draw notes
-  for (const note of this.wclip.all_notes)
-    {
-      const oct = floor (note.key / 12), key = note.key - oct * 12;
-      const ny = yoffset - oct * layout.oct_length - key * layout.row + 1;
-      const nx = round (note.tick * tickscale), nw = Math.max (1, round (note.duration * tickscale));
-      if (note.selected)
-	ctx.fillStyle = note_selected_color;
-      else
-	ctx.fillStyle = note_color;
-      ctx.fillRect (nx - lsx, ny - layout.row, nw, layout.row - 2);
-      if (0) // frame notes
-	{
-	  ctx.fillStyle = note_focus_color;
-	  ctx.strokeRect (nx - lsx, ny - layout.row, nw, layout.row - 2);
-	}
-    }
+  const draw_notes = (selected) => {
+    for (const note of this.wclip.all_notes)
+      {
+        if (note.selected == selected)
+          {
+            const oct = floor (note.key / 12), key = note.key - oct * 12;
+            const ny = yoffset - oct * layout.oct_length - key * layout.row + 1;
+            const nx = round (note.tick * tickscale), nw = Math.max (1, round (note.duration * tickscale));
+            if (note.selected)
+              ctx.fillStyle = note_selected_color;
+            else
+              ctx.fillStyle = note_color;
+            ctx.fillRect (nx - lsx, ny - layout.row, nw, layout.row - 2);
+            if (0) // frame notes
+              {
+                ctx.fillStyle = note_focus_color;
+                ctx.strokeRect (nx - lsx, ny - layout.row, nw, layout.row - 2);
+              }
+          }
+      }
+  };
+  // draw selected notes over unselected notes
+  draw_notes (false);
+  draw_notes (true);
 }
 
 /** Paint timeline digits and indicators


### PR DESCRIPTION
This branch contains some minor fixes/improvements for the piano roll.

- it contains a key binding (shift+up/down) to move notes one octave up/down (which is a pretty common operation)
- it draws selected notes over unselected notes, which is more intuitive
- it fixes the odd situation that if you had an unselected note which overlapped a selected note, your tool (sometimes) affected the unselected note, which is note intuitive, so now selected notes get a higher tool priority