### PR TITLE
ASE: project.cc: activate new tracks on creation if Project is active

### DIFF
--- a/ase/project.cc
+++ b/ase/project.cc
@@ -818,6 +818,8 @@ ProjectImpl::create_track ()
   tracks_.insert (tracks_.end() - int (havemaster), track);
   emit_event ("track", "insert", { { "track", track }, });
   track->_set_parent (this);
+  if (is_active())
+    track->_activate();
   emit_notify ("all_tracks");
   return track;
 }


### PR DESCRIPTION
Fixes #69.

It turned out that the reason CLAP support is currently unreliable is not in the CLAP code itself, but caused by the fact that the CLAP device never gets activated, and thus ignores midi events if you follow the steps to reproduce the problem (described in #69).