### PR TITLE
ase/cotask.hh: include optional header

### DIFF
--- a/ase/cotask.hh
+++ b/ase/cotask.hh
@@ -5,6 +5,7 @@
 #include <coroutine>
 #include <exception>
 #include <functional>
+#include <optional>
 #include <type_traits>
 
 namespace Ase {


### PR DESCRIPTION
Required to build on Ubuntu 26.04.1 LTS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation issues affecting code that uses `CoTask` with optional results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->