### PR TITLE
solidjs knob databubble fixes

### DIFF
--- a/ui/b/databubble.tsx
+++ b/ui/b/databubble.tsx
@@ -65,6 +65,19 @@ Extra_css`
 
 /** A mechanism to display data-bubble="" tooltip popups */
 class DataBubbleImpl {
+  bubblelayerparent: Element;
+  bubble: HTMLElement | undefined;
+  bubblediv: HTMLElement | undefined;
+  current: any;
+  stack: any[];
+  lasttext: string;
+  last_event: any;
+  buttonsdown: boolean;
+  coords: any;
+  restart_bubble_timer: any;
+  debounced_check: any;
+  zmovedel: (() => void) | undefined;
+  resizeob: ResizeObserver | undefined;
   bubble_layer()
   {
     const bubble_layer_id = '#b-shell-bubble-layer';
@@ -103,6 +116,28 @@ class DataBubbleImpl {
     this.zmovedel = App.zmoves_add (recheck_event);
 
     this.resizeob = new ResizeObserver (() => !!this.current && this.debounced_check());
+  }
+  /// Unhook zmove, disconnect observer, cancel debounces, remove bubble element.
+  dispose ()
+  {
+    if (this.zmovedel)
+      {
+	this.zmovedel();
+	this.zmovedel = undefined;
+      }
+    if (this.resizeob)
+      {
+	this.resizeob.disconnect();
+	this.resizeob = undefined;
+      }
+    this.restart_bubble_timer.cancel();
+    this.debounced_check.cancel();
+    if (this.current)
+      delete this.current.data_bubble_active;
+    this.current = null;
+    this.bubble?.remove();
+    this.bubble = undefined;
+    this.bubblediv = undefined;
   }
   check_showtime (showtime = false) {
     // check stack hide/show needs
@@ -227,10 +262,17 @@ class DataBubbleImpl {
 const UNSET = Symbol ('UNSET');
 
 class DataBubbleIface {
+  data_bubble: DataBubbleImpl | undefined;
   constructor (bubblelayerparent)
   {
     console.assert (!!bubblelayerparent);
     this.data_bubble = new DataBubbleImpl (bubblelayerparent);
+  }
+  /// Dispose the inner bubble instance.
+  dispose ()
+  {
+    this.data_bubble?.dispose();
+    this.data_bubble = undefined;
   }
   /// Set the `data-bubble` attribute of `element` to `text` or force its callback
   update (element, text = UNSET) {

--- a/ui/b/knob.tsx
+++ b/ui/b/knob.tsx
@@ -316,7 +316,7 @@ export function Knob (props: {
     if (props.disabled)   // let scroll events pass through, no value changes
       return;
     const d = Mouse.wheel_delta (event);
-    if ((root_el as any)?.[SPIN_DRAG]?.captureid === undefined && // not dragging
+    if ((sprite_el as any)?.[SPIN_DRAG]?.captureid === undefined && // not dragging
 	((!props2.hscroll && d.x != 0) ||
 	 (!props2.vscroll && d.y != 0))) // consume scroll iff hscroll/vscroll enabled
       return;	// only consume scroll events if enabled
@@ -364,14 +364,14 @@ export function Knob (props: {
         if (button1date && now - button1date <= 500)
           {
             button1date = 0;
-            spin_drag_stop (root_el);
+            spin_drag_stop (sprite_el);
             props.prop?.reset();
             return;
           }
         else
           button1date = now;
       }
-    spin_drag_start (root_el, event, drag_change);
+    spin_drag_start (sprite_el, event, drag_change);
   }
 
   function drag_change (distance: number)
@@ -388,7 +388,7 @@ export function Knob (props: {
 
   // Cleanup on unmount: release notify subscription and abort any in-flight spin drag
   onCleanup (() => {
-    spin_drag_stop (root_el);
+    spin_drag_stop (sprite_el);
     clear_notify_cb?.();
     clear_notify_cb = undefined;
   });

--- a/ui/b/shell.tsx
+++ b/ui/b/shell.tsx
@@ -267,6 +267,7 @@ class BShell extends Object {
     this.piano_current_clip_tickfn = [null,null];
     this.piano_roll_ = null;
     this.modal_dialogs_ = null;
+    this.data_bubble?.dispose();
     this.data_bubble = null;
     this.switch_panel2_ = null;
     this.switch_panel3_ = null;

--- a/ui/tests/TestList.g.mk
+++ b/ui/tests/TestList.g.mk
@@ -6,6 +6,7 @@ UI_TEST_LIST := \
   clip_test.test_clip_notes \
   clip_test.test_clip_range \
   contextmenu_test.test_contextmenu \
+  databubble_test.test_databubble \
   devicepanel_test.test_devicepanel \
   editable_test.test_editable \
   knob_test.test_knob \

--- a/ui/tests/TestList.g.mk
+++ b/ui/tests/TestList.g.mk
@@ -8,6 +8,7 @@ UI_TEST_LIST := \
   contextmenu_test.test_contextmenu \
   devicepanel_test.test_devicepanel \
   editable_test.test_editable \
+  knob_test.test_knob \
   numberinput_test.test_numberinput \
   project_test.test_project_basic \
   project_test.test_project_master_volume \

--- a/ui/tests/databubble_test.ts
+++ b/ui/tests/databubble_test.ts
@@ -1,0 +1,131 @@
+// This Source Code Form is licensed MPL-2.0: http://mozilla.org/MPL-2.0
+
+import DataBubbleIface from '../b/databubble';
+import * as Dom from '../dom';
+
+/// Count attached data-bubble elements.
+function count_bubbles (): number
+{
+  return document.querySelectorAll ('.b-data-bubble').length;
+}
+
+// == Test registry ==
+const sub_tests: [string, () => Promise<any>][] = [];
+
+/// Test that dispose releases zmove hook, observer and DOM node.
+async function test_databubble_dispose (): Promise<boolean>
+{
+  const shell_element = document.querySelector ('.b-shell');
+  if (!shell_element)
+    throw new Error ('Shell element not found in test environment');
+
+  const app: any = (window as any).App;
+  if (!app?.zmoves_add)
+    throw new Error ('App.zmoves_add not available in test environment');
+
+  // Track zmove deletions
+  let deleter_handed = false;
+  let deleter_called = false;
+  const prev_zmoves_add = app.zmoves_add.bind (app);
+  const RO = window.ResizeObserver;
+  let disconnect_delta: any = 0;
+  const prev_disconnect = RO.prototype.disconnect;
+  let dbiface: DataBubbleIface | undefined;
+  try {
+    app.zmoves_add = (hook: any) => {
+      const deleter = prev_zmoves_add (hook);
+      deleter_handed = true;
+      return () => { deleter_called = true; deleter(); };
+    };
+
+    RO.prototype.disconnect = function () {
+      disconnect_delta++;
+      prev_disconnect.call (this);
+    };
+
+    const bubbles_before = count_bubbles();
+    dbiface = new DataBubbleIface (shell_element);
+
+    // The new instance must attach its own bubble element
+    if (count_bubbles() != bubbles_before + 1)
+      throw new Error ('DataBubbleIface did not add a bubble element');
+    if (!deleter_handed)
+      throw new Error ('zmove deleter was not handed out');
+    if (disconnect_delta != 0)
+      throw new Error (`unexpected ResizeObserver disconnect before dispose: ${disconnect_delta}`);
+
+    dbiface.dispose();
+
+    if (!deleter_called)
+      throw new Error ('dispose did not delete the zmove hook');
+    if (count_bubbles() != bubbles_before)
+      throw new Error ('dispose did not remove the bubble element');
+    if (disconnect_delta != 1)
+      throw new Error (`dispose did not disconnect the ResizeObserver: ${disconnect_delta}`);
+
+    // repeated dispose must change nothing
+    dbiface.dispose();
+    dbiface.dispose();
+    if (count_bubbles() != bubbles_before)
+      throw new Error ('double dispose did not stay idempotent');
+    if (disconnect_delta != 1)
+      throw new Error (`double dispose caused extra disconnects: ${disconnect_delta}`);
+
+    return true;
+  } finally {
+    try {
+      dbiface?.dispose();
+    } finally {
+      app.zmoves_add = prev_zmoves_add;
+      RO.prototype.disconnect = prev_disconnect;
+    }
+  }
+}
+sub_tests.push (['dispose', test_databubble_dispose]);
+
+/// Test that dispose cancels pending debounced checks.
+async function test_databubble_dispose_debounce (): Promise<boolean>
+{
+  const shell_element = document.querySelector ('.b-shell');
+  if (!shell_element)
+    throw new Error ('Shell element not found in test environment');
+
+  const bubbles_before = count_bubbles();
+  const dbiface = new DataBubbleIface (shell_element);
+  const pending_element = document.createElement ('div');
+  shell_element.appendChild (pending_element);
+  try {
+    dbiface.force (pending_element);
+    document.body.dispatchEvent (new PointerEvent ('pointermove', { bubbles: true }));
+    dbiface.dispose();
+    await Dom.ui_wait (200);
+
+    if (count_bubbles() != bubbles_before)
+      throw new Error ('disposed debounce left a bubble element attached');
+  } finally {
+    dbiface.dispose();
+    pending_element.remove();
+  }
+
+  return true;
+}
+sub_tests.push (['dispose_debounce', test_databubble_dispose_debounce]);
+
+// == Master runner ==
+/// Runs all sub-tests in sequence.
+export async function test_databubble (): Promise<boolean>
+{
+  if (!sub_tests.length)
+    throw new Error ('databubble: no sub-tests registered');
+  const failures: string[] = [];
+  for (const [name, fn] of sub_tests) {
+    try {
+      await fn();
+    } catch (e) {
+      failures.push (`${name}: ${(e as Error)?.message ?? e}`);
+    }
+  }
+  if (failures.length)
+    throw new Error ('databubble failures:\n  ' + failures.join ('\n  '));
+  return true;
+}

--- a/ui/tests/knob_test.ts
+++ b/ui/tests/knob_test.ts
@@ -1,0 +1,220 @@
+// This Source Code Form is licensed MPL-2.0: http://mozilla.org/MPL-2.0
+
+import { createComponent, render } from 'solid-js/web';
+import { Knob } from '../b/knob';
+import * as Dom from '../dom';
+
+/// Minimal fake knob prop with normalized value 0..1.
+function make_fake_prop (value = 0.5)
+{
+  let val = value;
+  const listeners: (() => void)[] = [];
+  return {
+    label_: undefined as any,
+    nick_: undefined as any,
+    hints_: '',
+    get_text: async () => String (val),
+    fetch_: () => val,
+    get_normalized: async () => val,
+    set_normalized: async (v: number) => { val = v; listeners.forEach (l => l()); },
+    update_: async () => {},
+    reset: async () => { val = 0; },
+    on: (_ev: string, cb: () => void) => {
+      listeners.push (cb);
+      return () => {
+        const i = listeners.indexOf (cb);
+        if (i >= 0) listeners.splice (i, 1);
+      };
+    },
+  };
+}
+
+/// Spy on Shell.data_bubble.force/unforce, restoring the previous handlers.
+function stub_shell ()
+{
+  const force_calls: any[] = [];
+  const unforce_calls: any[] = [];
+  const shell: any = (globalThis as any).Shell;
+  if (!shell?.data_bubble)
+    throw new Error ('Shell.data_bubble not available in test environment');
+  const db = shell.data_bubble;
+  const prev_force = db.force.bind (db);
+  const prev_unforce = db.unforce.bind (db);
+  db.force = (el: any) => { force_calls.push (el); prev_force (el); };
+  db.unforce = (el: any) => { unforce_calls.push (el); prev_unforce (el); };
+  return {
+    force_calls,
+    unforce_calls,
+    restore: () => {
+      db.force = prev_force;
+      db.unforce = prev_unforce;
+    },
+  };
+}
+
+/// Mount a Knob and return its DOM helpers.
+function mount_knob (prop: any)
+{
+  const container = document.createElement ('div');
+  document.body.appendChild (container);
+  const dispose = render (() => createComponent (Knob, { prop }), container);
+  const sprite = () => container.querySelector ('#sprite') as HTMLElement | null;
+  // Avoid environment failures for pointer-lock machinery in headless mode.
+  const prep_sprite = () => {
+    const el = sprite();
+    if (!el) throw new Error ('knob #sprite not found');
+    (el as any).setPointerCapture = () => {};
+    (el as any).releasePointerCapture = () => {};
+    (el as any).requestPointerLock = () => {};
+    return el;
+  };
+  return {
+    container,
+    sprite: prep_sprite,
+    cleanup: () => {
+      dispose();
+      container.remove();
+    },
+  };
+}
+
+// == Test registry ==
+const sub_tests: [string, () => Promise<any>][] = [];
+
+/// Test that spin-drag state and data bubbles attach to the sprite, not the wrapper.
+async function test_knob_spindrag_element (): Promise<boolean>
+{
+  const shell = stub_shell();
+  const prop = make_fake_prop (0.5);
+  const knob = mount_knob (prop);
+
+  try {
+    await Dom.ui_next_frame();
+    const sprite = knob.sprite();
+
+    // Primary-button pointerdown starts a drag on the sprite
+    sprite.dispatchEvent (new PointerEvent ('pointerdown', {
+      buttons: 1, pointerId: 1, bubbles: true, cancelable: true,
+    }));
+
+    if (shell.force_calls.length != 1)
+      throw new Error (`data_bubble.force not called exactly once: ${shell.force_calls.length}`);
+    if (shell.force_calls[0] !== sprite)
+      throw new Error ('data_bubble.force targeted the wrapper instead of the sprite');
+
+    // Ending the drag with pointerup must stop it on the sprite
+    sprite.dispatchEvent (new PointerEvent ('pointerup', { bubbles: true, cancelable: true }));
+
+    if (shell.unforce_calls.length != 1)
+      throw new Error (`data_bubble.unforce not called exactly once: ${shell.unforce_calls.length}`);
+    if (shell.unforce_calls[0] !== sprite)
+      throw new Error ('data_bubble.unforce targeted the wrapper instead of the sprite');
+  } finally {
+    knob.cleanup();
+    shell.restore();
+  }
+
+  return true;
+}
+sub_tests.push (['spindrag_element', test_knob_spindrag_element]);
+
+/// Test that a drag stopped via the double-click path ends cleanly on the sprite.
+async function test_knob_spindrag_dblclick (): Promise<boolean>
+{
+  const shell = stub_shell();
+  const prop = make_fake_prop (0.5);
+  const knob = mount_knob (prop);
+
+  try {
+    await Dom.ui_next_frame();
+    const sprite = knob.sprite();
+
+    // Start a drag
+    sprite.dispatchEvent (new PointerEvent ('pointerdown', {
+      buttons: 1, pointerId: 1, bubbles: true, cancelable: true,
+    }));
+    if (shell.force_calls.length != 1)
+      throw new Error ('drag did not start');
+
+    // A second pointerdown within the double-click window resets the value and stops the drag
+    sprite.dispatchEvent (new PointerEvent ('pointerdown', {
+      buttons: 1, pointerId: 1, bubbles: true, cancelable: true,
+    }));
+
+    if (shell.unforce_calls.length != 1)
+      throw new Error (`double-click did not stop the drag: ${shell.unforce_calls.length} unforce calls`);
+    if (shell.unforce_calls[0] !== sprite)
+      throw new Error ('double-click stop targeted the wrapper instead of the sprite');
+
+    // After stopping, a new drag must be possible (drag state was cleared)
+    sprite.dispatchEvent (new PointerEvent ('pointerdown', {
+      buttons: 1, pointerId: 2, bubbles: true, cancelable: true,
+    }));
+    if (shell.force_calls.length < 2)
+      throw new Error (`drag state not cleared after double-click: ${shell.force_calls.length} force calls`);
+    sprite.dispatchEvent (new PointerEvent ('pointerup', { bubbles: true, cancelable: true }));
+  } finally {
+    knob.cleanup();
+    shell.restore();
+  }
+
+  return true;
+}
+sub_tests.push (['spindrag_dblclick', test_knob_spindrag_dblclick]);
+
+/// Test that the wheel guard consumes only enabled scroll directions when not dragging.
+async function test_knob_wheel_guard (): Promise<boolean>
+{
+  const shell = stub_shell();
+  const prop = make_fake_prop (0.5);
+  const knob = mount_knob (prop);
+
+  try {
+    await Dom.ui_next_frame();
+    await Dom.ui_next_frame();
+    const sprite = knob.sprite();
+
+    // Vertical wheel is enabled by default (vscroll) and must change the value
+    sprite.dispatchEvent (new WheelEvent ('wheel', {
+      deltaX: 0, deltaY: -100, bubbles: true, cancelable: true,
+    }));
+    await Dom.ui_next_frame();
+    const v = await prop.get_normalized();
+    if (!(v > 0.5))
+      throw new Error (`vertical wheel did not increase value: ${v}`);
+
+    // Horizontal wheel is disabled by default (hscroll=false) and must be ignored
+    sprite.dispatchEvent (new WheelEvent ('wheel', {
+      deltaX: -100, deltaY: 0, bubbles: true, cancelable: true,
+    }));
+    await Dom.ui_next_frame();
+    const v2 = await prop.get_normalized();
+    if (v2 != v)
+      throw new Error (`horizontal wheel changed value while disabled: ${v2}`);
+  } finally {
+    knob.cleanup();
+    shell.restore();
+  }
+
+  return true;
+}
+sub_tests.push (['wheel_guard', test_knob_wheel_guard]);
+
+// == Master runner ==
+/// Single exported entry point runs all sub-tests in sequence.
+export async function test_knob (): Promise<boolean>
+{
+  if (!sub_tests.length)
+    throw new Error ('knob: no sub-tests registered');
+  const failures: string[] = [];
+  for (const [name, fn] of sub_tests) {
+    try {
+      await fn();
+    } catch (e) {
+      failures.push (`${name}: ${(e as Error)?.message ?? e}`);
+    }
+  }
+  if (failures.length)
+    throw new Error ('knob failures:\n  ' + failures.join ('\n  '));
+  return true;
+}


### PR DESCRIPTION
- **ui/b/knob.tsx: attach spin-drag state to the sprite element**
- **ui/b/databubble.tsx: dispose zmove hook, observer and DOM node on project swap**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved knob dragging behavior for pointer, double-click, and wheel interactions.
  - Ensured data bubbles are fully cleaned up when reset or disposed, including pending activity and visual elements.
  - Prevented stale bubble elements and interaction hooks from remaining after cleanup.
  - Made cleanup safe to perform repeatedly.

- **Tests**
  - Added coverage for data-bubble cleanup and knob interaction behavior.
  - Expanded the UI test suite to run the new data-bubble and knob tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->