### PR TITLE
gcc 14 support

### DIFF
--- a/ase/cotask.hh
+++ b/ase/cotask.hh
@@ -41,7 +41,7 @@ struct CoTaskAux {
     constexpr bool await_ready() const noexcept { return false; }
     /// Resume the parent frame that is co_await-ing this CoTask<>
     std::coroutine_handle<>
-    await_suspend (std::coroutine_handle<promise_type> h)
+    await_suspend (std::coroutine_handle<promise_type> h) noexcept
     {
       auto &promise = h.promise();      // `h` is the CoTask<> handle, currently in co_return
       if (promise.continuation_)        // we have an awaiting caller

--- a/jsonipc/jsonipc.hh
+++ b/jsonipc/jsonipc.hh
@@ -884,7 +884,7 @@ struct typescript_name<std::unordered_map<std::string, T>> {
   static std::string name() { return "{ [key: string]: " + typescript_name<T>::name() + " }"; }
 };
 #define JSONIPC_MAP_TO_TYPESCRIPT(CXXTYPE,TSTYPE)                       \
-  template<> struct ::Jsonipc::typescript_name< CXXTYPE >  { static std::string name() { return TSTYPE; } }
+  template<> struct Jsonipc::typescript_name< CXXTYPE >  { static std::string name() { return TSTYPE; } }
 
 template<typename... Args> std::string
 typescript_arg_list()

--- a/misc/config-uname.mk
+++ b/misc/config-uname.mk
@@ -15,6 +15,7 @@ $(error CC/CXX mismatch, set both to gcc or both to clang: CC=$(CC) CCKIND=$(CCK
 endif
 HAVE_GCC	::= $(if $(findstring gcc,$(CXXKIND)),1,)
 HAVE_CLANG	::= $(if $(findstring clang,$(CXXKIND)),1,)
+$(if $(and $(HAVE_GCC),$(filter 13.%,$(CXXVERSION))),$(error Compiler 'CXX=$(CXX)' is too old, g++ >= 14 is required))
 ifeq ($(HAVE_GCC)$(HAVE_CLANG),)		# do we HAVE_ *any* recognized compiler?
 $(error Compiler '$(CXX)' not recognized, version identifier: $(CXXKIND))
 endif

--- a/misc/config-uname.mk
+++ b/misc/config-uname.mk
@@ -5,10 +5,16 @@
 uname_S		::= $(shell uname -s 2>/dev/null || echo None)
 uname_M		::= $(shell uname -m 2>/dev/null || echo None)
 uname_R		::= $(shell uname -r 2>/dev/null || echo None)
+CCVERSION	 != $(CC) --version 2>&1
+CCKIND		 != case '$(CCVERSION)'  in *"Free Software Foundation"*) echo gcc;; *clang*) echo clang;; *) echo UNKNOWN;; esac
 CXXVERSION	 != $(CXX) --version 2>&1
 CXXKIND		 != case '$(CXXVERSION)' in *"Free Software Foundation"*) echo gcc;; *clang*) echo clang;; *) echo UNKNOWN;; esac
-HAVE_GCC	::= $(if $(findstring $(CXXKIND), gcc),1,)
-HAVE_CLANG	::= $(if $(findstring $(CXXKIND), clang),1,)
+# CC and CXX must come from one compiler family, gcc-only flags break clang.
+ifneq ($(CCKIND),$(CXXKIND))
+$(error CC/CXX mismatch, set both to gcc or both to clang: CC=$(CC) CCKIND=$(CCKIND) CXX=$(CXX) CXXKIND=$(CXXKIND))
+endif
+HAVE_GCC	::= $(if $(findstring gcc,$(CXXKIND)),1,)
+HAVE_CLANG	::= $(if $(findstring clang,$(CXXKIND)),1,)
 ifeq ($(HAVE_GCC)$(HAVE_CLANG),)		# do we HAVE_ *any* recognized compiler?
 $(error Compiler '$(CXX)' not recognized, version identifier: $(CXXKIND))
 endif


### PR DESCRIPTION
- **misc/config-uname.mk: detect CC kind and enforce CC/CXX compiler match**
- **ase/cotask.hh: mark await_suspend as noexcept for gcc-14**
- **jsonipc/jsonipc.hh: remove leading :: from Jsonipc namespace in macro for gcc-14**
- **misc/config-uname.mk: require g++ >= 14**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Build configuration now detects C and C++ compiler versions and families more accurately.
  - Configuration reports an error when the selected C and C++ compilers belong to incompatible families.
  - GCC 13 is no longer supported; GCC/G++ 14 or newer is required.
  - Compiler capability indicators are now derived consistently from the selected C++ compiler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->