### PR TITLE
fix use after free 2

### DIFF
--- a/ase/project.cc
+++ b/ase/project.cc
@@ -344,6 +344,7 @@ ProjectImpl::deactivate_edit()
     transport.stop (true, true);
   transport.freePlaybackContext();
   edit_->cancelAnyPendingUpdates();
+  transport_listener_ = nullptr; // detach from edit_ and transport
   edit_ = nullptr;
 }
 
@@ -351,8 +352,6 @@ ProjectImpl::~ProjectImpl()
 {
   unregister_ase_obj (this, edit_.get());
   deactivate_edit();
-  transport_listener_ = nullptr;
-  edit_ = nullptr;
 }
 
 
@@ -386,6 +385,7 @@ TelemetryFieldS
 ProjectImpl::telemetry () const
 {
   TelemetryFieldS v;
+  return_unless (transport_listener_, v);
   v.push_back (telemetry_field ("current_tick", &transport_listener_->pos.tick));
   v.push_back (telemetry_field ("current_bar", &transport_listener_->pos.bar));
   v.push_back (telemetry_field ("current_beat", &transport_listener_->pos.beat));

--- a/ase/websocket.cc
+++ b/ase/websocket.cc
@@ -275,42 +275,49 @@ WebSocketServerImpl::io_handler (PollFD &pfd)
   auto it = clients_.find (fd);
   if (it == clients_.end())
     return false; // client gone
-  auto &client = it->second;
-  if (client.out_buffer.size()) {
+  if (it->second.out_buffer.size()) {
+    auto &client = it->second;
     ssize_t n = ::send (fd, client.out_buffer.data(), client.out_buffer.size(), 0);
     IODEBUG ("%s:%u:%s: send(%d,%d)\n", __FILE__, __LINE__, __func__, fd, n);
     if (n > 0)
       client.out_buffer.erase (0, n);
-    else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+    else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
       client.con->fatal_error();
+      it = clients_.find (fd);
+      return_unless (it != clients_.end(), false);
+    }
   }
   if ((pfd.revents & PollFD::IN) &&
-      client.con->get_state() != websocketpp::session::state::closed) {
+      it->second.con->get_state() != websocketpp::session::state::closed) {
     char buf[8192];
     ssize_t n = ::recv (fd, buf, sizeof (buf), 0);
     IODEBUG ("%s:%u:%s: recv(%d)=%d\n", __FILE__, __LINE__, __func__, fd, n);
     if (n > 0) {
       try {
-        client.con->read_all (buf, n);
+        it->second.con->read_all (buf, n);
       } catch (...) {
-        client.con->fatal_error();  // websocketpp error
+        it->second.con->fatal_error();  // websocketpp error
       }
     }
     else if (n == 0)
-      client.con->eof();
-    else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-      client.con->fatal_error();    // read EIO
-    }
+      it->second.con->eof();
+    else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+      it->second.con->fatal_error();    // read EIO
+    it = clients_.find (fd);
+    return_unless (it != clients_.end(), false);
   }
-  if (pfd.revents & (PollFD::ERR | PollFD::HUP | PollFD::NVAL)) // 0x8 0x10 0x20
-    client.con->fatal_error();    // fd EIO
-  if (client.con->get_state() == websocketpp::session::state::closed)
-    IODEBUG ("%s:%u:%s: closed fd=%d ob=%d io_errors=0x%x\n", __FILE__, __LINE__, __func__, fd, client.out_buffer.size(), pfd.revents & (PollFD::ERR | PollFD::HUP | PollFD::NVAL));
-  if (client.out_buffer.size())
+  if (pfd.revents & (PollFD::ERR | PollFD::HUP | PollFD::NVAL)) { // 0x8 0x10 0x20
+    it->second.con->fatal_error();    // fd EIO
+    it = clients_.find (fd);
+    return_unless (it != clients_.end(), false);
+  }
+  if (it->second.con->get_state() == websocketpp::session::state::closed)
+    IODEBUG ("%s:%u:%s: closed fd=%d ob=%d io_errors=0x%x\n", __FILE__, __LINE__, __func__, fd, it->second.out_buffer.size(), pfd.revents & (PollFD::ERR | PollFD::HUP | PollFD::NVAL));
+  if (it->second.out_buffer.size())
     pfd.events |= PollFD::OUT;
   else
     pfd.events &= ~PollFD::OUT;
-  const bool closed = client.out_buffer.empty() && client.con->get_state() == websocketpp::session::state::closed;
+  const bool closed = it->second.out_buffer.empty() && it->second.con->get_state() == websocketpp::session::state::closed;
   return !closed; // keep handler if not closed
 }
 

--- a/ase/websocket.cc
+++ b/ase/websocket.cc
@@ -275,6 +275,7 @@ WebSocketServerImpl::io_handler (PollFD &pfd)
   auto it = clients_.find (fd);
   if (it == clients_.end())
     return false; // client gone
+  const WppConnectionP con = it->second.con; // owning copy, reentrant close may erase the client
   if (it->second.out_buffer.size()) {
     auto &client = it->second;
     ssize_t n = ::send (fd, client.out_buffer.data(), client.out_buffer.size(), 0);
@@ -282,42 +283,42 @@ WebSocketServerImpl::io_handler (PollFD &pfd)
     if (n > 0)
       client.out_buffer.erase (0, n);
     else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-      client.con->fatal_error();
+      con->fatal_error();
       it = clients_.find (fd);
       return_unless (it != clients_.end(), false);
     }
   }
   if ((pfd.revents & PollFD::IN) &&
-      it->second.con->get_state() != websocketpp::session::state::closed) {
+      con->get_state() != websocketpp::session::state::closed) {
     char buf[8192];
     ssize_t n = ::recv (fd, buf, sizeof (buf), 0);
     IODEBUG ("%s:%u:%s: recv(%d)=%d\n", __FILE__, __LINE__, __func__, fd, n);
     if (n > 0) {
       try {
-        it->second.con->read_all (buf, n);
+        con->read_all (buf, n);
       } catch (...) {
-        it->second.con->fatal_error();  // websocketpp error
+        con->fatal_error();  // websocketpp error
       }
     }
     else if (n == 0)
-      it->second.con->eof();
+      con->eof();
     else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
-      it->second.con->fatal_error();    // read EIO
+      con->fatal_error();    // read EIO
     it = clients_.find (fd);
     return_unless (it != clients_.end(), false);
   }
   if (pfd.revents & (PollFD::ERR | PollFD::HUP | PollFD::NVAL)) { // 0x8 0x10 0x20
-    it->second.con->fatal_error();    // fd EIO
+    con->fatal_error();    // fd EIO
     it = clients_.find (fd);
     return_unless (it != clients_.end(), false);
   }
-  if (it->second.con->get_state() == websocketpp::session::state::closed)
+  if (con->get_state() == websocketpp::session::state::closed)
     IODEBUG ("%s:%u:%s: closed fd=%d ob=%d io_errors=0x%x\n", __FILE__, __LINE__, __func__, fd, it->second.out_buffer.size(), pfd.revents & (PollFD::ERR | PollFD::HUP | PollFD::NVAL));
   if (it->second.out_buffer.size())
     pfd.events |= PollFD::OUT;
   else
     pfd.events &= ~PollFD::OUT;
-  const bool closed = it->second.out_buffer.empty() && it->second.con->get_state() == websocketpp::session::state::closed;
+  const bool closed = it->second.out_buffer.empty() && con->get_state() == websocketpp::session::state::closed;
   return !closed; // keep handler if not closed
 }
 


### PR DESCRIPTION
- **ase/project.cc: fix use-after-free destroying the transport listener**
- **ase/websocket.cc: fix use-after-free in WebSocketServerImpl::io_handler**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tim-janik/anklang/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when ending or deactivating project editing sessions.
  * Prevented connection-related errors from causing invalid state or unexpected crashes.
  * Improved handling of failed, interrupted, or closed WebSocket connections.
  * Telemetry now safely reports no data when the associated connection is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->