### PR TITLE
.github/workflows/: simplify IRC notification and add offline tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,11 @@ jobs:
       if: ${{ always() && !env.ACT }}  # IRCBOT_JOBS indicates 'success'
       env: { IRCBOT_JOBS: "${{ join(needs.*.result, ' ') }}" }
       run: .github/workflows/ircbot.py -q -j "#Anklang" -G
+
+  Test-IrcBot:
+    # Least important job, kept last so its breakage cannot kill the real CI
+    runs-on: ubuntu-latest
+    steps:
+    - { uses: actions/checkout@v4, with: { fetch-depth: 0 } }
+    - name: Test IRC bot with mocked sockets
+      run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/workflows -p test_ircbot.py -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,13 @@ jobs:
       run: .github/workflows/ircbot.py -q -j "#Anklang" -G
 
   Test-IrcBot:
-    # Least important job, kept last so its breakage cannot kill the real CI
+    # Least important job, run last and non-gating so its breakage cannot kill the real CI
+    needs: [ ReleaseArtifacts, NobleClangTidy, CreateRelease, Ping-IRC ]
+    if: ${{ always() }}
+    continue-on-error: true
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
-    - { uses: actions/checkout@v4, with: { fetch-depth: 0 } }
+    - { uses: actions/checkout@v4, with: { fetch-depth: 0, persist-credentials: false } }
     - name: Test IRC bot with mocked sockets
       run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/workflows -p test_ircbot.py -v

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -14,6 +14,7 @@ timeout = 150
 wait_timeout = 15000
 socket_timeout = 30
 max_line_bytes = 512
+max_privmsg_bytes = 400
 github_event_data = None
 # Libera.Chat throttles message sending to 1 per 2 seconds, this applies
 # to bots too, see https://libera.chat/guides/faq#flood-exemptions-for-bots
@@ -71,11 +72,23 @@ def encode_line (text):
     raise Fatal ('IRC command exceeds the byte limit')
   return data
 
+def log_line (text):
+  command, separator, params = text.partition (' ')
+  if command.upper() == 'PASS':
+    return 'PASS <redacted>'
+  if command.upper() == 'JOIN' and separator and ' ' in params:
+    return 'JOIN ' + params.split (' ', 1)[0] + ' <redacted>'
+  return text
+
+irc_casemap = str.maketrans ('ABCDEFGHIJKLMNOPQRSTUVWXYZ[]\\^', 'abcdefghijklmnopqrstuvwxyz{}|~')
+def irc_equal (left, right):
+  return left.translate (irc_casemap) == right.translate (irc_casemap)
+
 def message_lines ():
   target = (args.j or args.J or args.n).split (' ')[0]
   if not args.message:
     return target, []
-  budget = max_line_bytes - len (('PRIVMSG ' + target + ' :\r\n').encode ('utf8'))
+  budget = max_privmsg_bytes - len (('PRIVMSG ' + target + ' :\r\n').encode ('utf8'))
   if budget < 4:
     raise Fatal ('IRC message target is too long')
   lines = []
@@ -114,7 +127,7 @@ def sendline (text):
   global args
   data = encode_line (text)
   if not args.quiet:
-    print ("PASS <redacted>" if text.split (" ", 1)[0].upper() == "PASS" else text, flush = True)
+    print (log_line (text), flush = True)
   previous_timeout = ircsock.gettimeout()
   try:
     ircsock.settimeout (socket_timeout)
@@ -156,13 +169,14 @@ def canread (milliseconds):
   return ircsock in rs
 
 readall_buffer = b'' # unterminated start of next line
-def readall (milliseconds = timeout):
+def readall (milliseconds = timeout, receive_milliseconds = None):
   global readall_buffer
   if not canread (milliseconds):
     return False
   previous_timeout = ircsock.gettimeout()
   try:
-    ircsock.settimeout (max (0.001, min (socket_timeout, milliseconds * 0.001)))
+    receive_milliseconds = milliseconds if receive_milliseconds is None else receive_milliseconds
+    ircsock.settimeout (max (0.001, min (socket_timeout, receive_milliseconds * 0.001)))
     buf = ircsock.recv (128 * 1024)
   finally:
     ircsock.settimeout (previous_timeout)
@@ -190,7 +204,7 @@ def waitfor (pred, milliseconds = wait_timeout):
     remaining = endtime - time.monotonic()
     if remaining <= 0:
       raise TimeoutError ('TIMEOUT: no matching reply within ' + str (milliseconds) + 'ms')
-    readall (min (remaining * 1000, 100))
+    readall (min (remaining * 1000, 100), remaining * 1000)
 
 def throttle ():
   # Sleep long enough to respect Libera.Chat's message rate limit
@@ -237,7 +251,7 @@ def register_nick ():
   for i in range (3):
     reply = waitfor (lambda r:
       (r.command == '001' and bool (r.params)) or
-      (r.command == '433' and len (r.params) >= 2 and r.params[1] == args.n))
+      (r.command == '433' and len (r.params) >= 2 and irc_equal (r.params[1], args.n)))
     if reply.command == '001':
       args.n = reply.params[0]
       return
@@ -345,8 +359,9 @@ def run_session ():
     sendline ("JOIN " + args.j)
     target = args.j.split (' ')[0]
     reply = waitfor (lambda r:
-      (r.command == 'JOIN' and r.prefix.split ('!', 1)[0] == args.n and r.params == [target]) or
-      (r.command in ('403', '471', '473', '474', '475') and len (r.params) >= 2 and r.params[1] == target))
+      (r.command == 'JOIN' and irc_equal (r.prefix.split ('!', 1)[0], args.n) and
+       len (r.params) == 1 and irc_equal (r.params[0], target)) or
+      (r.command in ('403', '471', '473', '474', '475') and len (r.params) >= 2 and irc_equal (r.params[1], target)))
     if reply.command == '471':
       raise Exception ('JOIN rejected, channel full (471)')
     if reply.command != 'JOIN':
@@ -357,7 +372,8 @@ def run_session ():
     throttle() # Libera.Chat allows 1 message per 2 seconds
     delivery_started = True
     sendline ("PRIVMSG " + target + " :" + line)
-    waitfor (lambda r: r.command == 'PRIVMSG' and r.prefix.split ('!', 1)[0] == args.n and r.params == [target, line])
+    waitfor (lambda r: r.command == 'PRIVMSG' and irc_equal (r.prefix.split ('!', 1)[0], args.n) and len (r.params) == 2 and
+             irc_equal (r.params[0], target) and r.params[1] == line)
   if lines:
     notified = True
 
@@ -455,6 +471,7 @@ def main (sysargs):
         # All message echoes were verified; a later LIST or QUIT failure
         # must not report the notification as failed or resend it.
         print (f'IRC: delivered (echo verified) on attempt {attempt}/{attempts}', file = sys.stderr, flush = True)
+        close_socket()
         delivered = True
         break
       print (f'IRC: attempt {attempt}/{attempts} failed: {e}', file = sys.stderr, flush = True)

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -264,63 +264,6 @@ def parse_args (sysargs):
   #print ('ARGS:', repr (args), flush = True)
   return args
 
-args = parse_args (sys.argv[1:])
-
-if args.G:
-  # $GITHUB_EVENT_PATH holds the verbatim webhook payload of the triggering event;
-  # the field layout of each event type is documented at
-  #   https://docs.github.com/en/webhooks/webhook-events-and-payloads
-  # with machine readable schemas at
-  #   https://github.com/octokit/webhooks/tree/main/payload-schemas/api.github.com
-  # note: payloads drift from these schemas in both directions (e.g. head_commit
-  # can be null, sender.user_view_type is payload-only), read all fields defensively
-  event_path = os.getenv ('GITHUB_EVENT_PATH')
-  if event_path and os.path.exists (event_path):
-    with open (event_path, 'r') as f:
-      github_event_data = json.load (f)
-
-# Derive announcement fields from the event payload; which events reach the bot
-# is decided by the calling workflow, the bot handles all payload shapes.
-if github_event_data:
-  ev = github_event_data
-  R = (ev.get ('repository') or {}).get ('full_name', '')
-  args.R = R if R else args.R
-  U = (ev.get ('pusher') or {}).get ('name', '')
-  args.U = U if U else args.U
-  ref = ev.get ('ref') or ''
-  if ref:
-    args.D = re.sub (r'^refs/(heads|tags)/', '', ref) # branch or tag name
-  head = ev.get ('head_commit') or {} # schema allows null
-  pr = ev.get ('pull_request') or {} # pull_request payloads: no ref/pusher/head_commit
-  subject = (head.get ('message', '').splitlines() or [ '' ])[0] # commit subject line
-  if pr and not subject: # pull_request payload: announce "action: title"
-    if pr.get ('number'):
-      args.D = '#' + str (pr['number'])
-    args.U = args.U or (ev.get ('sender') or {}).get ('login', '')
-    subject = pr.get ('title', '')
-    if subject and ev.get ('action'):
-      subject = ev['action'] + ': ' + subject
-  url = head.get ('url') or pr.get ('html_url') or ''
-  if not args.message and subject: # default message: commit subject or PR title
-    args.message = [ subject ]
-  if url and args.message:
-    args.message += [ '-', url ]
-  # overall job status: IRCBOT_JOBS passes the workflow's needs.*.result values
-  # joined by spaces; anything but success|skipped is announced as FAILURE, the
-  # run conclusion itself is handled by GitHub
-  needs_results = os.getenv ('IRCBOT_JOBS', '').split()
-  failed = [ r for r in needs_results if r not in ( 'success', 'skipped' ) ]
-  if not args.S and needs_results:
-    args.S = 'FAILURE' if failed else 'SUCCESS'
-  print ('EVENT:', args.R or '-', args.U or '-', args.D or '-', url or '-', '| jobs:',
-         ' '.join (needs_results) or '-', file = sys.stderr)
-
-# Never open a remote connection without a message to deliver
-if not args.message and not args.l:
-  argparser.error ('a message is required (or -l to list channels)')
-
-if args.message and not args.quiet:
-  print (format_msg (args, 1))
 def register_connection ():
   # CAP negotiation for echo-message (delivery verification), then USER/NICK
   global have_echo_message
@@ -401,29 +344,92 @@ def run_session ():
     pass
   close_socket()
 
-# Connection drops, missing replies and unverified messages are retried,
-# the bot only exits successfully once delivery was confirmed by the server.
-orig_nick = args.n
-delivered = False
-attempts = 3
-for attempt in range (1, attempts + 1):
-  try:
-    args.n = orig_nick
-    run_session()
-    delivered = True
-    verified = 'echo verified' if have_echo_message else 'unverified, no echo-message cap'
-    print (f'IRC: delivered ({verified}) on attempt {attempt}/{attempts}', file = sys.stderr, flush = True)
-    break
-  except Fatal as e:
-    print (f'IRC: fatal: {e}', file = sys.stderr, flush = True)
-    close_socket()
-    break # don't retry a server ban
-  except Exception as e:
-    print (f'IRC: attempt {attempt}/{attempts} failed: {e}', file = sys.stderr, flush = True)
-    close_socket()
-    if attempt < attempts:
-      time.sleep (5 * 2 ** (attempt - 1)) # exponential backoff before reconnecting
-# Nonzero exit is reserved for notification failures; a failed build is
-# communicated via the [FAILURE] tag and GitHub's own run conclusion
-if not delivered:
-  sys.exit (1)
+def main (sysargs):
+  global args, github_event_data
+  args = parse_args (sysargs)
+
+  if args.G:
+    # $GITHUB_EVENT_PATH holds the verbatim webhook payload of the triggering event;
+    # the field layout of each event type is documented at
+    #   https://docs.github.com/en/webhooks/webhook-events-and-payloads
+    # with machine readable schemas at
+    #   https://github.com/octokit/webhooks/tree/main/payload-schemas/api.github.com
+    # note: payloads drift from these schemas in both directions (e.g. head_commit
+    # can be null, sender.user_view_type is payload-only), read all fields defensively
+    event_path = os.getenv ('GITHUB_EVENT_PATH')
+    if event_path and os.path.exists (event_path):
+      with open (event_path, 'r') as f:
+        github_event_data = json.load (f)
+
+  # Derive announcement fields from the event payload; which events reach the bot
+  # is decided by the calling workflow, the bot handles all payload shapes.
+  if github_event_data:
+    ev = github_event_data
+    R = (ev.get ('repository') or {}).get ('full_name', '')
+    args.R = R if R else args.R
+    U = (ev.get ('pusher') or {}).get ('name', '')
+    args.U = U if U else args.U
+    ref = ev.get ('ref') or ''
+    if ref:
+      args.D = re.sub (r'^refs/(heads|tags)/', '', ref) # branch or tag name
+    head = ev.get ('head_commit') or {} # schema allows null
+    pr = ev.get ('pull_request') or {} # pull_request payloads: no ref/pusher/head_commit
+    subject = (head.get ('message', '').splitlines() or [ '' ])[0] # commit subject line
+    if pr and not subject: # pull_request payload: announce "action: title"
+      if pr.get ('number'):
+        args.D = '#' + str (pr['number'])
+      args.U = args.U or (ev.get ('sender') or {}).get ('login', '')
+      subject = pr.get ('title', '')
+      if subject and ev.get ('action'):
+        subject = ev['action'] + ': ' + subject
+    url = head.get ('url') or pr.get ('html_url') or ''
+    if not args.message and subject: # default message: commit subject or PR title
+      args.message = [ subject ]
+    if url and args.message:
+      args.message += [ '-', url ]
+    # overall job status: IRCBOT_JOBS passes the workflow's needs.*.result values
+    # joined by spaces; anything but success|skipped is announced as FAILURE, the
+    # run conclusion itself is handled by GitHub
+    needs_results = os.getenv ('IRCBOT_JOBS', '').split()
+    failed = [ r for r in needs_results if r not in ( 'success', 'skipped' ) ]
+    if not args.S and needs_results:
+      args.S = 'FAILURE' if failed else 'SUCCESS'
+    print ('EVENT:', args.R or '-', args.U or '-', args.D or '-', url or '-', '| jobs:',
+           ' '.join (needs_results) or '-', file = sys.stderr)
+
+  # Never open a remote connection without a message to deliver
+  if not args.message and not args.l:
+    argparser.error ('a message is required (or -l to list channels)')
+
+  if args.message and not args.quiet:
+    print (format_msg (args, 1))
+  # Connection drops, missing replies and unverified messages are retried,
+  # the bot only exits successfully once delivery was confirmed by the server.
+  orig_nick = args.n
+  delivered = False
+  attempts = 3
+  for attempt in range (1, attempts + 1):
+    try:
+      args.n = orig_nick
+      run_session()
+      delivered = True
+      verified = 'echo verified' if have_echo_message else 'unverified, no echo-message cap'
+      print (f'IRC: delivered ({verified}) on attempt {attempt}/{attempts}', file = sys.stderr, flush = True)
+      break
+    except Fatal as e:
+      print (f'IRC: fatal: {e}', file = sys.stderr, flush = True)
+      close_socket()
+      break # don't retry a server ban
+    except Exception as e:
+      print (f'IRC: attempt {attempt}/{attempts} failed: {e}', file = sys.stderr, flush = True)
+      close_socket()
+      if attempt < attempts:
+        time.sleep (5 * 2 ** (attempt - 1)) # exponential backoff before reconnecting
+  # Nonzero exit is reserved for notification failures; a failed build is
+  # communicated via the [FAILURE] tag and GitHub's own run conclusion
+  if not delivered:
+    sys.exit (1)
+
+
+if __name__ == "__main__":
+  main (sys.argv[1:])

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -58,7 +58,7 @@ def format_msg (args, how = 2):
 def sendline (text):
   global args
   if not args.quiet:
-    print (text, flush = True)
+    print ("PASS <redacted>" if text.split (" ", 1)[0].upper() == "PASS" else text, flush = True)
   msg = text + "\r\n"
   ircsock.send (msg.encode ('utf8'))
 

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # This Source Code Form is licensed MPL-2.0: http://mozilla.org/MPL/2.0
 import sys, os, re, socket, select, time, unicodedata, json, ssl
+from collections import deque, namedtuple
 
 # https://datatracker.ietf.org/doc/html/rfc1459
 
@@ -17,8 +18,8 @@ github_event_data = None
 # to bots too, see https://libera.chat/guides/faq#flood-exemptions-for-bots
 message_rate = 2.0
 last_message = 0.0
-captured_lines = [] # lines collected while capturing=True
-capturing = False
+replies = deque()
+Message = namedtuple ("Message", "prefix command params")
 have_echo_message = False # server confirms deliveries via echo-message cap
 
 def colors (how):
@@ -79,14 +80,11 @@ def close_socket ():
 
 def reset_session_state ():
   # fresh state per attempt, so retries aren't confused by leftover data
-  global readall_buffer, expecting_commands, check_cmds, capturing
+  global readall_buffer, have_echo_message
   close_socket()
   readall_buffer = b''
-  expecting_commands = []
-  check_cmds = []
-  seen_cmds.clear()
-  captured_lines.clear()
-  capturing = False
+  replies.clear()
+  have_echo_message = False
 
 def connect (server, port):
   global ircsock
@@ -107,57 +105,47 @@ def canread (milliseconds):
 readall_buffer = b'' # unterminated start of next line
 def readall (milliseconds = timeout):
   global readall_buffer
-  gotlines = False
-  while canread (milliseconds):
-    milliseconds = 0
+  if not canread (milliseconds):
+    return False
+  previous_timeout = ircsock.gettimeout()
+  try:
+    ircsock.settimeout (max (0.001, min (socket_timeout, milliseconds * 0.001)))
     buf = ircsock.recv (128 * 1024)
-    if len (buf) == 0:
-      raise Exception ('SOCKET CLOSED: connection lost') # triggers session retry
-    gotlines = True
-    readall_buffer += buf
-    if readall_buffer.find (b'\n') >= 0:
-      lines, readall_buffer = readall_buffer.rsplit (b'\n', 1)
-      lines = lines.decode ('utf8', 'replace')
-      for l in lines.split ('\n'):
-        if l:
-          gotline (l.rstrip())
-  return gotlines
+  finally:
+    ircsock.settimeout (previous_timeout)
+  if not buf:
+    raise ConnectionError ('SOCKET CLOSED: connection lost') # triggers session retry
+  readall_buffer += buf
+  if b'\n' in readall_buffer:
+    lines, readall_buffer = readall_buffer.rsplit (b'\n', 1)
+    for line in lines.decode ('utf8', 'replace').split ('\n'):
+      if line:
+        gotline (line.removesuffix ('\r'))
+  return True
 
 class Fatal (Exception):
   pass # non-retryable session failure (e.g. server ban)
 
 def waitfor (pred, milliseconds = wait_timeout):
-  # Read incoming lines until pred (line) matches, returns the matched line
-  global capturing
-  endtime = time.time() + milliseconds * 0.001
-  capturing = True
-  captured_lines.clear()
-  try:
-    while True:
-      try:
-        readall (100)
-      except Exception:
-        # socket closed: final check of captured lines before propagating
-        for l in captured_lines:
-          if pred (l):
-            return l
-        raise
-      for l in captured_lines:
-        if pred (l):
-          return l
-      captured_lines.clear()
-      if time.time() >= endtime:
-        raise Exception ('TIMEOUT: no matching reply within ' + str (milliseconds) + 'ms')
-  finally:
-    capturing = False
+  # Read incoming replies until pred (reply) matches, returns the matched reply
+  endtime = time.monotonic() + milliseconds * 0.001
+  while True:
+    while replies:
+      reply = replies.popleft()
+      if pred (reply):
+        return reply
+    remaining = endtime - time.monotonic()
+    if remaining <= 0:
+      raise TimeoutError ('TIMEOUT: no matching reply within ' + str (milliseconds) + 'ms')
+    readall (min (remaining * 1000, 100))
 
 def throttle ():
   # Sleep long enough to respect Libera.Chat's message rate limit
   global last_message
-  elapsed = time.time() - last_message
+  elapsed = time.monotonic() - last_message
   if elapsed < message_rate:
     time.sleep (message_rate - elapsed)
-  last_message = time.time()
+  last_message = time.monotonic()
 
 def is_printable(c):
   # Catch control sequences like:
@@ -166,59 +154,48 @@ def is_printable(c):
   # c287 → U+0087 (C0 control character: "Cancel Character").
   return unicodedata.category(c)[0] != 'C'
 
-def gotline (msg):
-  global args
-  if capturing:
-    captured_lines.append (msg)
-  if not args.quiet:
-    filtered_msg = ''.join (c for c in msg if is_printable (c))
-    print (filtered_msg, flush = True)
-  cmdargs = re.split (' +', msg)
-  if cmdargs:
-    prefix = ''
-    if cmdargs[0] and cmdargs[0][0] == ':':
-      prefix = cmdargs[0]
-      cmdargs = cmdargs[1:]
-      if not cmdargs:
-        return
-    gotcmd (prefix, cmdargs[0], cmdargs[1:])
+def parse_line (line):
+  if line.startswith ('@'):
+    line = line.partition (' ')[2]
+  prefix = ''
+  if line.startswith (':'):
+    prefix, _, line = line[1:].partition (' ')
+  middle, separator, trailing = line.partition (' :')
+  words = middle.split()
+  if not words:
+    return Message (prefix, '', [])
+  params = words[1:] + ([trailing] if separator else [])
+  return Message (prefix, words[0].upper(), params)
 
-expecting_commands = []
-check_cmds = []
-seen_cmds = [] # all commands seen so far, includes cmds seen during waitfor()
-def gotcmd (prefix, cmd, args):
-  global expecting_commands, check_cmds
-  seen_cmds.append (cmd)
-  if check_cmds:
-    try: check_cmds.remove (cmd)
-    except: pass
-  if cmd in expecting_commands:
-    expecting_commands = []
-  if cmd == 'PING':
-    return sendline ('PONG ' + ' '.join (args))
+def gotline (line):
+  if not args.quiet:
+    print (''.join (c for c in line if is_printable (c)), flush = True)
+  reply = parse_line (line)
+  if reply.command == '465':
+    raise Fatal ('server ban (465), not retrying')
+  if reply.command == 'PING':
+    if reply.params:
+      sendline ('PONG ' + ' '.join (reply.params[:-1] + [':' + reply.params[-1]]))
+  elif reply.command:
+    replies.append (reply)
 
 def register_nick ():
   # Wait for registration (001), retry with a suffixed nick on 433 (in use)
-  global args
   for i in range (3):
-    reply = waitfor (lambda l: re.search (r'\b(001|433|465)\b', l))
-    if re.search (r'\b001\b', reply):
+    reply = waitfor (lambda r:
+      (r.command == '001' and bool (r.params)) or
+      (r.command == '433' and len (r.params) >= 2 and r.params[1] == args.n))
+    if reply.command == '001':
+      args.n = reply.params[0]
       return
-    if re.search (r'\b465\b', reply):
-      raise Fatal ('server ban (465), not retrying: ' + reply)
-    args.n += '_' # 433: nickname is already in use
-    sendline ("NICK " + args.n)
+    if i < 2:
+      args.n += '_' # 433: nickname is already in use
+      sendline ("NICK " + args.n)
   raise Exception ('NICK: nickname already in use, all retries failed')
 
-def expect (what = []):
-  global expecting_commands
-  expecting_commands = what if isinstance (what, (list, tuple)) else [ what ]
-  for c in seen_cmds: # handle commands seen during earlier waitfor() calls
-    if c in expecting_commands:
-      expecting_commands = []
-  while expecting_commands and readall (wait_timeout): pass
-  if expecting_commands:
-    raise (Exception ('MISSING REPLY: ' + ' | '.join (expecting_commands)))
+def expect (what):
+  commands = what if isinstance (what, (list, tuple)) else [what]
+  return waitfor (lambda r: r.command in commands)
 
 usage_help = '''
 Simple IRC bot for short messages.
@@ -277,8 +254,9 @@ def register_connection ():
   # how deliveries are verified without channel operator privileges
   sendline ("CAP LS 302") # IRCv3: CAP negotiation starts with CAP LS
   sendline ("CAP REQ :echo-message")
-  ackline = waitfor (lambda l: re.search (r' CAP .* (ACK|NAK)', l))
-  have_echo_message = not re.search (r' CAP .* NAK', ackline)
+  ackline = waitfor (lambda r: r.command == 'CAP' and len (r.params) >= 3 and
+    r.params[1] in ('ACK', 'NAK') and 'echo-message' in r.params[-1].split())
+  have_echo_message = ackline.params[1] == 'ACK' and 'echo-message' in ackline.params[-1].split()
   if not have_echo_message:
     print ('IRC: server lacks echo-message, delivery cannot be verified', file = sys.stderr, flush = True)
   ircbot_pass = os.getenv ("IRCBOT_PASS")
@@ -299,18 +277,18 @@ def run_session ():
 
   if args.ping:
     sendline ("PING :pleasegetbacktome")
-    expect ('PONG')
+    waitfor (lambda r: r.command == 'PONG' and r.params and r.params[-1] == 'pleasegetbacktome')
 
   if args.j:
     sendline ("JOIN " + args.j)
-    # wait for the join echo or a rejection numeric (403, 471, 473, 474, 475)
-    reply = waitfor (lambda l: re.search (r'\b(JOIN|403|471|473|474|475)\b', l))
-    if re.search (r'\bJOIN\b', reply):
-      pass # joined, join echo received
-    elif re.search (r'\b471\b', reply):
-      raise Exception ('JOIN rejected, channel full (471), retrying: ' + reply)
-    else:
-      raise Fatal ('JOIN rejected: ' + reply)
+    target = args.j.split (' ')[0]
+    reply = waitfor (lambda r:
+      (r.command == 'JOIN' and r.prefix.split ('!', 1)[0] == args.n and r.params == [target]) or
+      (r.command in ('403', '471', '473', '474', '475') and len (r.params) >= 2 and r.params[1] == target))
+    if reply.command == '471':
+      raise Exception ('JOIN rejected, channel full (471)')
+    if reply.command != 'JOIN':
+      raise Fatal ('JOIN rejected: ' + reply.command)
 
   msg = format_msg (args)
   for line in re.split ('\n ?', msg):
@@ -320,27 +298,13 @@ def run_session ():
       sendline ("PRIVMSG " + channel + " :" + line)
       if have_echo_message:
         # delivery is only confirmed once the server echoes the message back
-        waitfor (lambda l: re.search (r' PRIVMSG ' + re.escape (channel) + r' :' + re.escape (line[:64]), l), 15000)
+        waitfor (lambda r: r.command == 'PRIVMSG' and r.prefix.split ('!', 1)[0] == args.n and r.params == [channel, line])
       else:
         readall()
 
   if args.l:
-    global check_cmds
     sendline ("LIST")
-    check_cmds = [ '322' ]
     expect ('323')
-    if check_cmds:
-      # empty list, retry after 60seconds
-      time.sleep (30)
-      check_cmds = [ 'PING' ]
-      readall()
-      if check_cmds:
-        sendline ("PING :pleasegetbacktome")
-        expect ('PONG')
-      time.sleep (30)
-      readall()
-      sendline ("LIST")
-      expect ('323')
 
   readall (500)
   try:

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -13,6 +13,7 @@ ircsock = None
 timeout = 150
 wait_timeout = 15000
 socket_timeout = 30
+max_line_bytes = 512
 github_event_data = None
 # Libera.Chat throttles message sending to 1 per 2 seconds, this applies
 # to bots too, see https://libera.chat/guides/faq#flood-exemptions-for-bots
@@ -45,27 +46,77 @@ def status_color (txt, c):
   return c.YELLOW
 
 def format_msg (args, how = 2):
-  msg = ' '.join (args.message)
+  msg = '\n'.join (clean_text (line) for line in ' '.join (args.message).split ('\n'))
   c = colors (how)
   if args.S:
-    msg = '[' + status_color (args.S, c) + args.S.upper() + c.RESET + '] ' + msg
+    msg = '[' + status_color (args.S, c) + clean_text (args.S).upper() + c.RESET + '] ' + msg
   if args.D:
-    msg = c.CYAN + args.D + c.RESET + ' ' + msg
+    msg = c.CYAN + clean_text (args.D) + c.RESET + ' ' + msg
   if args.U:
-    msg = c.ORANGE + args.U + c.RESET + ' ' + msg
+    msg = c.ORANGE + clean_text (args.U) + c.RESET + ' ' + msg
   if args.R:
-    msg = '[' + c.BLUE + args.R + c.RESET + '] ' + msg
+    msg = '[' + c.BLUE + clean_text (args.R) + c.RESET + '] ' + msg
   return msg
+
+def clean_text (text):
+  return ''.join (' ' if unicodedata.category (c) == 'Cc' else c for c in text)
+
+def encode_line (text):
+  if any (c in text for c in '\r\n\0'):
+    raise Fatal ('IRC command contains a line break or NUL')
+  data = (text + '\r\n').encode ('utf8')
+  if len (data) > max_line_bytes:
+    raise Fatal ('IRC command exceeds the byte limit')
+  return data
+
+def message_lines ():
+  target = (args.j or args.J or args.n).split (' ')[0]
+  if not args.message:
+    return target, []
+  budget = max_line_bytes - len (('PRIVMSG ' + target + ' :\r\n').encode ('utf8'))
+  if budget < 4:
+    raise Fatal ('IRC message target is too long')
+  lines = []
+  for line in re.split ('\n ?', format_msg (args)):
+    chunk = ''
+    size = 0
+    for char in line:
+      width = len (char.encode ('utf8'))
+      if size + width > budget:
+        lines.append (chunk)
+        chunk, size = '', 0
+      chunk += char
+      size += width
+    if chunk:
+      lines.append (chunk)
+  return target, lines
+
+def validate_commands ():
+  for value in (args.n, args.s, args.j, args.J):
+    if clean_text (value) != value:
+      raise Fatal ('IRC connection arguments contain control characters')
+  if not args.n or any (c.isspace() for c in args.n) or args.n.startswith (':'):
+    raise Fatal ('Invalid IRC nickname')
+  target, lines = message_lines()
+  if args.message and not lines:
+    raise Fatal ('Message has no text to send')
+  commands = ['USER ' + args.n + ' localhost ' + args.s + ' :' + args.n, 'NICK ' + args.n]
+  if args.j:
+    commands.append ('JOIN ' + args.j)
+  if os.getenv ('IRCBOT_PASS'):
+    commands.append ('PASS ' + os.environ['IRCBOT_PASS'])
+  for command in commands + ['PRIVMSG ' + target + ' :' + line for line in lines]:
+    encode_line (command)
 
 def sendline (text):
   global args
+  data = encode_line (text)
   if not args.quiet:
     print ("PASS <redacted>" if text.split (" ", 1)[0].upper() == "PASS" else text, flush = True)
-  msg = text + "\r\n"
   previous_timeout = ircsock.gettimeout()
   try:
     ircsock.settimeout (socket_timeout)
-    ircsock.sendall (msg.encode ('utf8'))
+    ircsock.sendall (data)
   finally:
     ircsock.settimeout (previous_timeout)
 
@@ -271,6 +322,7 @@ def register_connection ():
 def run_session ():
   # One IRC session: connect, register, join, send (and verify) the message
   reset_session_state()
+  validate_commands()
   connect (args.s, args.p)
   readall (500)
   register_connection()
@@ -290,17 +342,15 @@ def run_session ():
     if reply.command != 'JOIN':
       raise Fatal ('JOIN rejected: ' + reply.command)
 
-  msg = format_msg (args)
-  for line in re.split ('\n ?', msg):
-    channel = (args.j or args.J or args.n).split (' ')[0] # drop JOIN key part
-    if line:
-      throttle() # Libera.Chat allows 1 message per 2 seconds
-      sendline ("PRIVMSG " + channel + " :" + line)
-      if have_echo_message:
-        # delivery is only confirmed once the server echoes the message back
-        waitfor (lambda r: r.command == 'PRIVMSG' and r.prefix.split ('!', 1)[0] == args.n and r.params == [channel, line])
-      else:
-        readall()
+  target, lines = message_lines()
+  for line in lines:
+    throttle() # Libera.Chat allows 1 message per 2 seconds
+    sendline ("PRIVMSG " + target + " :" + line)
+    if have_echo_message:
+      # delivery is only confirmed once the server echoes the message back
+      waitfor (lambda r: r.command == 'PRIVMSG' and r.prefix.split ('!', 1)[0] == args.n and r.params == [target, line])
+    else:
+      readall()
 
   if args.l:
     sendline ("LIST")

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -22,6 +22,8 @@ last_message = 0.0
 replies = deque()
 Message = namedtuple ("Message", "prefix command params")
 have_echo_message = False # server confirms deliveries via echo-message cap
+delivery_started = False # a PRIVMSG send was attempted, retrying could duplicate it
+notified = False # all message echoes were verified, LIST failure must not fail the run
 
 def colors (how):
   E = '\u001b['
@@ -251,8 +253,9 @@ def expect (what):
 usage_help = '''
 Simple IRC bot for short messages.
 A password for authentication can be set via $IRCBOT_PASS.
-Connection failures and unverified messages are retried 3 times; a
-message only counts as delivered once the server echoed it back.
+Connection failures before sending are retried up to 3 times.
+Sending requires echo-message support; each message must be echoed back.
+Once sending starts, failures stop the bot without resending messages.
 Messages are throttled to Libera.Chat's rate limit of 1 per 2 seconds,
 see https://libera.chat/guides/faq#flood-exemptions-for-bots
 With -G, repository, user, branch, commit subject and URL are auto-filled
@@ -302,25 +305,32 @@ def register_connection ():
   # CAP negotiation for echo-message (delivery verification), then USER/NICK
   global have_echo_message
   # echo-message makes the server send back our own messages, this is
-  # how deliveries are verified without channel operator privileges
-  sendline ("CAP LS 302") # IRCv3: CAP negotiation starts with CAP LS
-  sendline ("CAP REQ :echo-message")
-  ackline = waitfor (lambda r: r.command == 'CAP' and len (r.params) >= 3 and
-    r.params[1] in ('ACK', 'NAK') and 'echo-message' in r.params[-1].split())
-  have_echo_message = ackline.params[1] == 'ACK' and 'echo-message' in ackline.params[-1].split()
-  if not have_echo_message:
-    print ('IRC: server lacks echo-message, delivery cannot be verified', file = sys.stderr, flush = True)
+  # how deliveries are verified without channel operator privileges.
+  # List-only sessions need no echo verification, so they skip CAP entirely
+  # and rely on register_nick() plus expect('251') below.
+  if args.message:
+    sendline ("CAP LS 302") # IRCv3: CAP negotiation starts with CAP LS
+    sendline ("CAP REQ :echo-message")
+    ackline = waitfor (lambda r: r.command == 'CAP' and len (r.params) >= 3 and
+      r.params[1] in ('ACK', 'NAK') and 'echo-message' in r.params[-1].split())
+    have_echo_message = ackline.params[1] == 'ACK' and 'echo-message' in ackline.params[-1].split()
+    if not have_echo_message:
+      raise Fatal ('server lacks echo-message; refusing unverified delivery')
+  else:
+    have_echo_message = False
   ircbot_pass = os.getenv ("IRCBOT_PASS")
   if ircbot_pass:
     sendline ("PASS " + ircbot_pass)
   sendline ("USER " + args.n + " localhost " + args.s + " :" + args.n)
   sendline ("NICK " + args.n)
-  sendline ("CAP END")
+  if args.message:
+    sendline ("CAP END")
   register_nick()
   expect ('251') # LUSER reply
 
 def run_session ():
   # One IRC session: connect, register, join, send (and verify) the message
+  global delivery_started, notified
   reset_session_state()
   validate_commands()
   connect (args.s, args.p)
@@ -345,19 +355,18 @@ def run_session ():
   target, lines = message_lines()
   for line in lines:
     throttle() # Libera.Chat allows 1 message per 2 seconds
+    delivery_started = True
     sendline ("PRIVMSG " + target + " :" + line)
-    if have_echo_message:
-      # delivery is only confirmed once the server echoes the message back
-      waitfor (lambda r: r.command == 'PRIVMSG' and r.prefix.split ('!', 1)[0] == args.n and r.params == [target, line])
-    else:
-      readall()
+    waitfor (lambda r: r.command == 'PRIVMSG' and r.prefix.split ('!', 1)[0] == args.n and r.params == [target, line])
+  if lines:
+    notified = True
 
   if args.l:
     sendline ("LIST")
     expect ('323')
 
-  readall (500)
   try:
+    readall (500)
     sendline ("QUIT :Bye Bye")
     expect (['QUIT', 'ERROR'])
   except Exception:
@@ -365,8 +374,11 @@ def run_session ():
   close_socket()
 
 def main (sysargs):
-  global args, github_event_data
+  global args, github_event_data, delivery_started, notified
   args = parse_args (sysargs)
+  github_event_data = None
+  delivery_started = False
+  notified = False
 
   if args.G:
     # $GITHUB_EVENT_PATH holds the verbatim webhook payload of the triggering event;
@@ -423,8 +435,6 @@ def main (sysargs):
 
   if args.message and not args.quiet:
     print (format_msg (args, 1))
-  # Connection drops, missing replies and unverified messages are retried,
-  # the bot only exits successfully once delivery was confirmed by the server.
   orig_nick = args.n
   delivered = False
   attempts = 3
@@ -433,16 +443,25 @@ def main (sysargs):
       args.n = orig_nick
       run_session()
       delivered = True
-      verified = 'echo verified' if have_echo_message else 'unverified, no echo-message cap'
-      print (f'IRC: delivered ({verified}) on attempt {attempt}/{attempts}', file = sys.stderr, flush = True)
+      result = 'delivered (echo verified)' if notified else 'channel list received'
+      print (f'IRC: {result} on attempt {attempt}/{attempts}', file = sys.stderr, flush = True)
       break
     except Fatal as e:
       print (f'IRC: fatal: {e}', file = sys.stderr, flush = True)
       close_socket()
       break # don't retry a server ban
     except Exception as e:
+      if notified:
+        # All message echoes were verified; a later LIST or QUIT failure
+        # must not report the notification as failed or resend it.
+        print (f'IRC: delivered (echo verified) on attempt {attempt}/{attempts}', file = sys.stderr, flush = True)
+        delivered = True
+        break
       print (f'IRC: attempt {attempt}/{attempts} failed: {e}', file = sys.stderr, flush = True)
       close_socket()
+      if delivery_started:
+        print ('IRC: delivery may have occurred; not retrying', file = sys.stderr, flush = True)
+        break
       if attempt < attempts:
         time.sleep (5 * 2 ** (attempt - 1)) # exponential backoff before reconnecting
   # Nonzero exit is reserved for notification failures; a failed build is

--- a/.github/workflows/ircbot.py
+++ b/.github/workflows/ircbot.py
@@ -11,6 +11,7 @@ nickname = "YYBOT"
 ircsock = None
 timeout = 150
 wait_timeout = 15000
+socket_timeout = 30
 github_event_data = None
 # Libera.Chat throttles message sending to 1 per 2 seconds, this applies
 # to bots too, see https://libera.chat/guides/faq#flood-exemptions-for-bots
@@ -60,7 +61,12 @@ def sendline (text):
   if not args.quiet:
     print ("PASS <redacted>" if text.split (" ", 1)[0].upper() == "PASS" else text, flush = True)
   msg = text + "\r\n"
-  ircsock.send (msg.encode ('utf8'))
+  previous_timeout = ircsock.gettimeout()
+  try:
+    ircsock.settimeout (socket_timeout)
+    ircsock.sendall (msg.encode ('utf8'))
+  finally:
+    ircsock.settimeout (previous_timeout)
 
 def close_socket ():
   global ircsock
@@ -85,7 +91,7 @@ def reset_session_state ():
 def connect (server, port):
   global ircsock
   ircsock = socket.socket (socket.AF_INET, socket.SOCK_STREAM)
-  ircsock.settimeout (30) # connect and TLS handshake must not hang CI forever
+  ircsock.settimeout (socket_timeout) # connect and TLS handshake must not hang CI forever
   if args.tls:
     ctx = ssl.create_default_context()
     ircsock = ctx.wrap_socket (ircsock, server_hostname = server)

--- a/.github/workflows/test_ircbot.py
+++ b/.github/workflows/test_ircbot.py
@@ -168,6 +168,13 @@ class BotTests (unittest.TestCase):
       self.bot.sendline ("NICK test")
     self.assertEqual (output.getvalue(), "NICK test\n")
 
+  def test_channel_key_is_redacted_but_sent (self):
+    output = io.StringIO()
+    with contextlib.redirect_stdout (output):
+      self.bot.sendline ("JOIN #test dummy-channel-key")
+    self.assertEqual (output.getvalue(), "JOIN #test <redacted>\n")
+    self.bot.ircsock.sendall.assert_called_with (b"JOIN #test dummy-channel-key\r\n")
+
   def test_partial_writes_send_complete_utf8_command (self):
     self.bot.args.quiet = True
     self.bot.ircsock = PartialSocket()
@@ -254,10 +261,10 @@ class BotTests (unittest.TestCase):
       self.bot.ircsock = server
       original_read = self.bot.readall
 
-      def flood (milliseconds):
+      def flood (milliseconds, receive_milliseconds = None):
         clock.sleep (0.01)
         server.queue ('PING :still-here')
-        return original_read (milliseconds)
+        return original_read (milliseconds, receive_milliseconds)
 
       with mock.patch.object (self.bot, 'readall', side_effect = flood):
         start = clock.now
@@ -265,6 +272,22 @@ class BotTests (unittest.TestCase):
           self.bot.waitfor (lambda r: r.command == '001', 50)
       self.assertLess (clock.now - start, 0.1)
       self.assertTrue (all (line == 'PONG :still-here' for line in server.sent))
+
+  def test_reply_read_uses_remaining_deadline (self):
+    with self.mock_server() as (server, clock):
+      self.bot.ircsock = server
+      server.incoming.append (b'pending TLS data')
+
+      def delayed_recv (size):
+        self.assertGreater (server.timeout, 0.9)
+        clock.sleep (0.15)
+        return b':mock 001 YYBOT :welcome\r\n'
+
+      with mock.patch.object (server, 'recv', side_effect = delayed_recv):
+        reply = self.bot.waitfor (lambda r: r.command == '001', 1000)
+      self.assertEqual (reply.params[0], 'YYBOT')
+      self.assertEqual (clock.now, 100.15)
+      self.assertIsNone (server.timeout)
 
   def test_real_ban_is_fatal (self):
     self.bot.args.quiet = True
@@ -283,6 +306,22 @@ class BotTests (unittest.TestCase):
       with self.assertRaises (TimeoutError):
         self.bot.run_session()
       self.assertFalse (any (line.startswith ('PRIVMSG ') for line in server.sent))
+
+  def test_join_and_echo_use_irc_case_mapping (self):
+    with self.mock_server() as (server, clock):
+      self.bot.args.j = '#TE[ST'
+
+      def respond (line):
+        if line.startswith ('JOIN '):
+          server.queue (':yybot!u@mock JOIN :#te{st')
+        elif line.startswith ('PRIVMSG '):
+          server.queue (':yybot!u@mock PRIVMSG #te{st :' + line.split (' :', 1)[1])
+        else:
+          server.default_response (line)
+
+      server.respond = respond
+      self.bot.run_session()
+      self.assertIn ('PRIVMSG #TE[ST :hello', server.sent)
 
   def test_echo_matches_sender_target_and_entire_text (self):
     for echo in (':other!u@mock PRIVMSG #test :hello', ':YYBOT!u@mock PRIVMSG #other :hello',
@@ -322,7 +361,9 @@ class BotTests (unittest.TestCase):
       messages = [line for line in server.sent if line.startswith ('PRIVMSG ')]
       self.assertGreater (len (messages), 1)
       self.assertEqual (''.join (line.split (' :', 1)[1] for line in messages), subject)
-      self.assertTrue (all (len ((line + '\r\n').encode()) <= self.bot.max_line_bytes for line in messages))
+      self.assertTrue (all (len ((line + '\r\n').encode()) <= self.bot.max_privmsg_bytes for line in messages))
+      echoes = [f':YYBOT!user@mock {line}\r\n'.encode() for line in messages]
+      self.assertTrue (all (len (line) <= self.bot.max_line_bytes for line in echoes))
 
   def test_command_injection_is_rejected_before_socket_use (self):
     for value in ('PASS secret\r\nJOIN #bad', 'PRIVMSG #test :bad\0text', 'NICK ' + 'x' * 512):
@@ -490,6 +531,8 @@ class BotTests (unittest.TestCase):
       self.assertIn ('delivered (echo verified)', output)
       self.assertEqual (self.bot.socket.socket.call_count, 1)
       self.assertEqual (server.sent.count ('PRIVMSG #test :hello'), 1)
+      self.assertTrue (server.closed)
+      self.assertIsNone (self.bot.ircsock)
 
   def test_empty_message_fails_before_connect (self):
     with self.mock_server() as (server, clock):
@@ -529,6 +572,17 @@ class BotTests (unittest.TestCase):
       self.assertIn ('PASS dummy-secret', server.sent)
       self.assertIn ('PASS <redacted>', output.getvalue())
       self.assertNotIn ('dummy-secret', output.getvalue())
+
+  def test_channel_key_registration_never_logs_dummy_secret (self):
+    with self.mock_server() as (server, clock):
+      self.bot.args.quiet = False
+      self.bot.args.j = '#test dummy-channel-key'
+      output = io.StringIO()
+      with contextlib.redirect_stdout (output), contextlib.redirect_stderr (output):
+        self.bot.run_session()
+      self.assertIn ('JOIN #test dummy-channel-key', server.sent)
+      self.assertIn ('JOIN #test <redacted>', output.getvalue())
+      self.assertNotIn ('dummy-channel-key', output.getvalue())
 
   def test_ping_requires_its_own_pong_token (self):
     for correct in (False, True):

--- a/.github/workflows/test_ircbot.py
+++ b/.github/workflows/test_ircbot.py
@@ -1,0 +1,556 @@
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+
+def deny_network (event, args):
+  if event.startswith ("socket."):
+    raise AssertionError ("IRC tests must not use real sockets: " + event)
+
+
+sys.addaudithook (deny_network)
+
+
+def load_bot ():
+  spec = importlib.util.spec_from_file_location ("ircbot", Path (__file__).with_name ("ircbot.py"))
+  bot = importlib.util.module_from_spec (spec)
+  spec.loader.exec_module (bot)
+  return bot
+
+
+class PartialSocket:
+  def __init__ (self, stalled = False):
+    self.data = bytearray()
+    self.timeout = None
+    self.write_timeout = None
+    self.stalled = stalled
+
+  def gettimeout (self):
+    return self.timeout
+
+  def settimeout (self, value):
+    self.timeout = value
+
+  def send (self, data):
+    self.write_timeout = self.timeout
+    if self.stalled:
+      raise TimeoutError ("mock write timed out")
+    count = min (3, len (data))
+    self.data.extend (data[:count])
+    return count
+
+  def sendall (self, data):
+    while data:
+      data = data[self.send (data):]
+
+
+class FakeClock:
+  def __init__ (self):
+    self.now = 100.0
+
+  def monotonic (self):
+    return self.now
+
+  def sleep (self, seconds):
+    self.now += seconds
+
+
+class MockServer (PartialSocket):
+  def __init__ (self):
+    super().__init__()
+    self.incoming = []
+    self.sent = []
+    self.nick = 'YYBOT'
+    self.closed = False
+    self.address = None
+    self.respond = self.default_response
+
+  def connect (self, address):
+    self.address = address
+
+  def setblocking (self, blocking):
+    self.timeout = None if blocking else 0
+
+  def close (self):
+    self.closed = True
+
+  def pending (self):
+    return len (self.incoming)
+
+  def recv (self, size):
+    return self.incoming.pop (0)
+
+  def queue (self, *lines):
+    self.incoming.append (('\r\n'.join (lines) + '\r\n').encode())
+
+  def sendall (self, data):
+    super().sendall (data)
+    line = data.decode().removesuffix ('\r\n')
+    self.sent.append (line)
+    self.respond (line)
+
+  def default_response (self, line):
+    if line == 'CAP REQ :echo-message':
+      self.queue (':mock CAP * ACK :echo-message')
+    elif line.startswith ('NICK '):
+      self.nick = line[5:]
+      self.queue (f':mock 001 {self.nick} :welcome', f':mock 251 {self.nick} :users')
+    elif line == 'CAP END':
+      self.queue (f':mock 001 {self.nick} :welcome', f':mock 251 {self.nick} :users')
+    elif line.startswith ('JOIN '):
+      self.queue (f':{self.nick}!user@mock JOIN :' + line[5:].split (' ')[0])
+    elif line.startswith ('PRIVMSG '):
+      self.queue (f':{self.nick}!user@mock ' + line)
+    elif line.startswith ('PING '):
+      self.queue (':mock PONG mock ' + line[5:])
+    elif line == 'LIST':
+      self.queue (f':mock 323 {self.nick} :End of LIST')
+    elif line.startswith ('QUIT '):
+      self.queue ('ERROR :Closing link')
+
+
+class BotTests (unittest.TestCase):
+  def setUp (self):
+    self.bot = load_bot()
+    self.bot.args = self.bot.parse_args (["-j", "#test", "hello"])
+    self.bot.ircsock = mock.Mock()
+
+  @contextlib.contextmanager
+  def mock_server (self, server = None):
+    server = server or MockServer()
+    clock = FakeClock()
+
+    def select_ready (readers, writers, errors, seconds):
+      clock.sleep (0.001 if server.incoming else seconds)
+      return (readers if server.incoming else [], [], [])
+
+    with contextlib.ExitStack() as stack:
+      stack.enter_context (mock.patch.object (self.bot.socket, 'socket', return_value = server))
+      tls = stack.enter_context (mock.patch.object (self.bot.ssl, 'create_default_context'))
+      tls.return_value.wrap_socket.return_value = server
+      stack.enter_context (mock.patch.object (self.bot.select, 'select', side_effect = select_ready))
+      stack.enter_context (mock.patch.object (self.bot.time, 'monotonic', side_effect = clock.monotonic))
+      stack.enter_context (mock.patch.object (self.bot.time, 'sleep', side_effect = clock.sleep))
+      stack.enter_context (mock.patch.dict (self.bot.os.environ, {}, clear = True))
+      self.bot.args = self.bot.parse_args (['-q', '-s', 'mock.invalid', '-j', '#test', 'hello'])
+      yield server, clock
+
+  def test_import_has_no_cli_or_network_side_effects (self):
+    with mock.patch.object (sys, "argv", ["ircbot.py", "--invalid-option"]):
+      with mock.patch ("time.sleep", side_effect = AssertionError ("unexpected sleep")):
+        load_bot()
+
+  def test_password_is_redacted_but_sent (self):
+    for command in ("PASS", "pass"):
+      with self.subTest (command = command):
+        output = io.StringIO()
+        with contextlib.redirect_stdout (output):
+          self.bot.sendline (command + " dummy-password")
+        self.assertNotIn ("dummy-password", output.getvalue())
+        self.assertEqual (output.getvalue(), "PASS <redacted>\n")
+        self.bot.ircsock.sendall.assert_called_with ((command + " dummy-password\r\n").encode())
+
+  def test_quiet_password_has_no_log (self):
+    self.bot.args.quiet = True
+    output = io.StringIO()
+    with contextlib.redirect_stdout (output):
+      self.bot.sendline ("PASS dummy-password")
+    self.assertEqual (output.getvalue(), "")
+
+  def test_ordinary_command_is_logged (self):
+    output = io.StringIO()
+    with contextlib.redirect_stdout (output):
+      self.bot.sendline ("NICK test")
+    self.assertEqual (output.getvalue(), "NICK test\n")
+
+  def test_partial_writes_send_complete_utf8_command (self):
+    self.bot.args.quiet = True
+    self.bot.ircsock = PartialSocket()
+    self.bot.sendline ("PRIVMSG #test :Grüße")
+    self.assertEqual (self.bot.ircsock.data, "PRIVMSG #test :Grüße\r\n".encode())
+    self.assertEqual (self.bot.ircsock.write_timeout, self.bot.socket_timeout)
+    self.assertIsNone (self.bot.ircsock.timeout)
+
+  def test_stalled_write_fails_and_restores_timeout (self):
+    self.bot.args.quiet = True
+    self.bot.ircsock = PartialSocket (stalled = True)
+    self.bot.ircsock.timeout = 7
+    with self.assertRaises (TimeoutError):
+      self.bot.sendline ("PING :test")
+    self.assertEqual (self.bot.ircsock.write_timeout, self.bot.socket_timeout)
+    self.assertEqual (self.bot.ircsock.timeout, 7)
+
+  def test_parser_preserves_tagged_message_and_trailing_spaces (self):
+    reply = self.bot.parse_line ('@label=test :nick!u@host PRIVMSG #test :text with spaces  ')
+    self.assertEqual (reply.prefix, 'nick!u@host')
+    self.assertEqual (reply.command, 'PRIVMSG')
+    self.assertEqual (reply.params, ['#test', 'text with spaces  '])
+
+  def test_session_uses_only_mock_server (self):
+    with self.mock_server() as (server, clock):
+      self.bot.run_session()
+      self.assertEqual (server.address, ('mock.invalid', self.bot.port))
+      self.assertIn ('PRIVMSG #test :hello', server.sent)
+      self.assertTrue (server.closed)
+
+  def test_notice_text_does_not_complete_registration (self):
+    self.bot.args.quiet = True
+    self.bot.gotline (':mock NOTICE * :001 welcome; 433 unavailable; 465 banned')
+    self.bot.gotline (':mock 001 actual-nick :welcome')
+    self.bot.register_nick()
+    self.assertEqual (self.bot.args.n, 'actual-nick')
+
+  def test_batched_replies_are_preserved (self):
+    with self.mock_server() as (server, clock):
+      self.bot.ircsock = server
+      server.queue (':mock 001 YYBOT :welcome', ':mock 251 YYBOT :users')
+      self.bot.register_nick()
+      reply = self.bot.expect ('251')
+      self.assertEqual (reply.command, '251')
+
+  def test_fragmented_utf8_reply_is_reassembled (self):
+    with self.mock_server() as (server, clock):
+      self.bot.ircsock = server
+      raw = ':mock NOTICE YYBOT :Grüße  \r\n'.encode()
+      server.incoming.extend (bytes ([byte]) for byte in raw)
+      reply = self.bot.expect ('NOTICE')
+      self.assertEqual (reply.params, ['YYBOT', 'Grüße  '])
+
+  def test_nickname_collision_waits_for_replacement (self):
+    self.bot.args.quiet = True
+    self.bot.gotline (':mock 433 * unrelated :in use')
+    self.bot.gotline (':mock 433 * YYBOT :in use')
+    self.bot.gotline (':mock 001 YYBOT_ :welcome')
+    self.bot.register_nick()
+    self.assertEqual (self.bot.args.n, 'YYBOT_')
+    self.bot.ircsock.sendall.assert_called_once_with (b'NICK YYBOT_\r\n')
+
+  def test_capability_ack_ignores_unrelated_replies (self):
+    with self.mock_server() as (server, clock):
+      def respond (line):
+        if line == 'CAP REQ :echo-message':
+          server.queue (':mock NOTICE * :CAP * ACK :echo-message', ':mock CAP * ACK :unrelated')
+        server.default_response (line)
+
+      server.respond = respond
+      self.bot.run_session()
+      self.assertTrue (self.bot.have_echo_message)
+
+  def test_used_reply_cannot_satisfy_later_wait (self):
+    with self.mock_server() as (server, clock):
+      self.bot.ircsock = server
+      server.queue (':mock PONG mock :token')
+      self.bot.expect ('PONG')
+      with self.assertRaises (TimeoutError):
+        self.bot.expect ('PONG')
+
+  def test_continuous_pings_do_not_extend_deadline (self):
+    with self.mock_server() as (server, clock):
+      self.bot.ircsock = server
+      original_read = self.bot.readall
+
+      def flood (milliseconds):
+        clock.sleep (0.01)
+        server.queue ('PING :still-here')
+        return original_read (milliseconds)
+
+      with mock.patch.object (self.bot, 'readall', side_effect = flood):
+        start = clock.now
+        with self.assertRaises (TimeoutError):
+          self.bot.waitfor (lambda r: r.command == '001', 50)
+      self.assertLess (clock.now - start, 0.1)
+      self.assertTrue (all (line == 'PONG :still-here' for line in server.sent))
+
+  def test_real_ban_is_fatal (self):
+    self.bot.args.quiet = True
+    with self.assertRaises (self.bot.Fatal):
+      self.bot.gotline (':mock 465 YYBOT :banned')
+
+  def test_join_matches_own_nick_and_requested_channel (self):
+    with self.mock_server() as (server, clock):
+      def respond (line):
+        if line.startswith ('JOIN '):
+          server.queue (':other!u@mock JOIN :#test', ':YYBOT!u@mock JOIN :#other', ':mock NOTICE YYBOT :JOIN #test')
+        else:
+          server.default_response (line)
+
+      server.respond = respond
+      with self.assertRaises (TimeoutError):
+        self.bot.run_session()
+      self.assertFalse (any (line.startswith ('PRIVMSG ') for line in server.sent))
+
+  def test_echo_matches_sender_target_and_entire_text (self):
+    for echo in (':other!u@mock PRIVMSG #test :hello', ':YYBOT!u@mock PRIVMSG #other :hello',
+                 ':YYBOT!u@mock PRIVMSG #test :hello extra', ':mock NOTICE YYBOT :PRIVMSG #test :hello'):
+      with self.subTest (echo = echo), self.mock_server() as (server, clock):
+        def respond (line):
+          if line.startswith ('PRIVMSG '):
+            server.queue (echo)
+          else:
+            server.default_response (line)
+
+        server.respond = respond
+        with self.assertRaises (TimeoutError):
+          self.bot.run_session()
+
+  def test_echo_retains_trailing_spaces (self):
+    with self.mock_server() as (server, clock):
+      self.bot.args.message = ['hello  ']
+      self.bot.run_session()
+      self.assertIn ('PRIVMSG #test :hello  ', server.sent)
+
+  def test_reset_discards_previous_session (self):
+    self.bot.args.quiet = True
+    self.bot.have_echo_message = True
+    self.bot.gotline (':mock 251 YYBOT :users')
+    self.bot.readall_buffer = b'partial'
+    self.bot.reset_session_state()
+    self.assertFalse (self.bot.replies)
+    self.assertFalse (self.bot.have_echo_message)
+    self.assertEqual (self.bot.readall_buffer, b'')
+
+  def test_unicode_subject_is_split_without_losing_text (self):
+    with self.mock_server() as (server, clock):
+      subject = 'Grüße 🌻 ' * 200
+      self.bot.args.message = [subject]
+      self.bot.run_session()
+      messages = [line for line in server.sent if line.startswith ('PRIVMSG ')]
+      self.assertGreater (len (messages), 1)
+      self.assertEqual (''.join (line.split (' :', 1)[1] for line in messages), subject)
+      self.assertTrue (all (len ((line + '\r\n').encode()) <= self.bot.max_line_bytes for line in messages))
+
+  def test_command_injection_is_rejected_before_socket_use (self):
+    for value in ('PASS secret\r\nJOIN #bad', 'PRIVMSG #test :bad\0text', 'NICK ' + 'x' * 512):
+      with self.subTest (value = value), self.assertRaises (self.bot.Fatal):
+        self.bot.sendline (value)
+    self.bot.ircsock.sendall.assert_not_called()
+
+  def test_bad_connection_arguments_fail_before_connect (self):
+    for name, value in (('j', '#test\r\nJOIN #bad'), ('n', 'bad nick'), ('n', 'x' * 512)):
+      with self.subTest (name = name), self.mock_server() as (server, clock):
+        setattr (self.bot.args, name, value)
+        with self.assertRaises (self.bot.Fatal):
+          self.bot.run_session()
+        self.assertIsNone (server.address)
+
+  def test_message_controls_are_text_not_commands (self):
+    with self.mock_server() as (server, clock):
+      self.bot.args.message = ['hello\r\nJOIN #bad\0\t\x1b']
+      self.bot.run_session()
+      messages = [line for line in server.sent if line.startswith ('PRIVMSG ')]
+      self.assertEqual (messages, ['PRIVMSG #test :hello ', 'PRIVMSG #test :JOIN #bad   '])
+      self.assertNotIn ('JOIN #bad', server.sent)
+
+  def test_multiline_messages_keep_rate_limit (self):
+    with self.mock_server() as (server, clock):
+      self.bot.args.message = ['one\ntwo\nthree']
+      sent_at = []
+
+      def respond (line):
+        if line.startswith ('PRIVMSG '):
+          sent_at.append (clock.now)
+        server.default_response (line)
+
+      server.respond = respond
+      self.bot.run_session()
+      self.assertEqual (len (sent_at), 3)
+      self.assertTrue (all (b - a >= self.bot.message_rate for a, b in zip (sent_at, sent_at[1:])))
+
+  def run_main (self, *arguments):
+    output = io.StringIO()
+    status = 0
+    with contextlib.redirect_stderr (output):
+      try:
+        self.bot.main (['-q', '-s', 'mock.invalid', '-j', '#test', *arguments])
+      except SystemExit as error:
+        status = error.code
+    return status, output.getvalue()
+
+  def test_network_guard_blocks_socket_creation (self):
+    with self.assertRaisesRegex (AssertionError, 'must not use real sockets'):
+      self.bot.socket.socket()
+
+  def test_missing_echo_capability_prevents_sending (self):
+    with self.mock_server() as (server, clock):
+      def respond (line):
+        if line == 'CAP REQ :echo-message':
+          server.queue (':mock CAP * NAK :echo-message')
+        else:
+          server.default_response (line)
+
+      server.respond = respond
+      status, output = self.run_main ('hello')
+      self.assertEqual (status, 1)
+      self.assertIn ('refusing unverified delivery', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertFalse (any (line.startswith ('PRIVMSG ') for line in server.sent))
+
+  def test_lost_second_echo_does_not_resend_or_continue (self):
+    with self.mock_server() as (server, clock):
+      def respond (line):
+        if line != 'PRIVMSG #test :two':
+          server.default_response (line)
+
+      server.respond = respond
+      status, output = self.run_main ('one\ntwo\nthree')
+      self.assertEqual (status, 1)
+      self.assertIn ('delivery may have occurred; not retrying', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertEqual ([line for line in server.sent if line.startswith ('PRIVMSG ')],
+                        ['PRIVMSG #test :one', 'PRIVMSG #test :two'])
+
+  def test_partial_message_write_does_not_retry (self):
+    with self.mock_server() as (server, clock):
+      original_send = server.sendall
+
+      def partial_write (data):
+        if data.startswith (b'PRIVMSG '):
+          server.data.extend (data[:12])
+          raise TimeoutError ('mock partial write')
+        original_send (data)
+
+      with mock.patch.object (server, 'sendall', side_effect = partial_write):
+        status, output = self.run_main ('hello')
+      self.assertEqual (status, 1)
+      self.assertIn ('delivery may have occurred; not retrying', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertEqual (server.data.count (b'PRIVMSG '), 1)
+
+  def test_disconnect_after_verified_delivery_is_success (self):
+    with self.mock_server() as (server, clock):
+      def respond (line):
+        server.default_response (line)
+        if line.startswith ('PRIVMSG '):
+          server.incoming.append (b'')
+
+      server.respond = respond
+      status, output = self.run_main ('hello')
+      self.assertEqual (status, 0)
+      self.assertIn ('delivered (echo verified)', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertTrue (server.closed)
+
+  def test_connection_failure_can_retry_before_sending (self):
+    with self.mock_server() as (server, clock):
+      with mock.patch.object (server, 'connect', side_effect = [ConnectionError ('mock failure'), None]):
+        status, output = self.run_main ('hello')
+      self.assertEqual (status, 0)
+      self.assertIn ('attempt 2/3', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 2)
+      self.assertEqual (server.sent.count ('PRIVMSG #test :hello'), 1)
+
+  def test_connection_retries_are_bounded (self):
+    with self.mock_server() as (server, clock):
+      with mock.patch.object (server, 'connect', side_effect = ConnectionError ('mock failure')):
+        status, output = self.run_main ('hello')
+      self.assertEqual (status, 1)
+      self.assertEqual (self.bot.socket.socket.call_count, 3)
+      self.assertEqual (server.sent, [])
+
+  def test_ban_stops_without_retry (self):
+    with self.mock_server() as (server, clock):
+      server.queue (':mock 465 YYBOT :banned')
+      status, output = self.run_main ('hello')
+      self.assertEqual (status, 1)
+      self.assertIn ('server ban (465), not retrying', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertEqual (server.sent, [])
+
+  def test_verified_multiline_delivery_succeeds_once (self):
+    with self.mock_server() as (server, clock):
+      status, output = self.run_main ('one\ntwo')
+      self.assertEqual (status, 0)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertEqual (server.sent.count ('PRIVMSG #test :one'), 1)
+      self.assertEqual (server.sent.count ('PRIVMSG #test :two'), 1)
+
+  def test_list_only_skips_cap_and_succeeds_without_echo (self):
+    with self.mock_server() as (server, clock):
+      status, output = self.run_main ('-l', '-R', 'some/repository')
+      self.assertEqual (status, 0)
+      self.assertIn ('channel list received', output)
+      self.assertEqual (server.sent.count ('LIST'), 1)
+      self.assertFalse (any (line.startswith ('PRIVMSG ') for line in server.sent))
+      self.assertFalse (any (line.startswith ('CAP ') for line in server.sent))
+
+  def test_list_failure_after_delivery_reports_delivery (self):
+    with self.mock_server() as (server, clock):
+      def respond (line):
+        if line != 'LIST':
+          server.default_response (line)
+
+      server.respond = respond
+      status, output = self.run_main ('-l', 'hello')
+      self.assertEqual (status, 0)
+      self.assertIn ('delivered (echo verified)', output)
+      self.assertEqual (self.bot.socket.socket.call_count, 1)
+      self.assertEqual (server.sent.count ('PRIVMSG #test :hello'), 1)
+
+  def test_empty_message_fails_before_connect (self):
+    with self.mock_server() as (server, clock):
+      status, output = self.run_main ('\n')
+      self.assertEqual (status, 1)
+      self.assertIn ('no text to send', output)
+      self.bot.socket.socket.assert_not_called()
+
+  def test_github_notification_uses_sanitized_event_fields (self):
+    with self.mock_server() as (server, clock):
+      event = {'repository': {'full_name': 'owner/repo'}, 'pusher': {'name': 'author\r\nQUIT'},
+               'ref': 'refs/heads/trunk', 'head_commit': {'message': 'Fix the bot\nDetails', 'url': 'https://example.invalid/commit'}}
+      self.bot.os.environ.update (GITHUB_EVENT_PATH = 'mock-event.json', IRCBOT_JOBS = 'success failure')
+      with mock.patch.object (self.bot.os.path, 'exists', return_value = True):
+        with mock.patch ('builtins.open', mock.mock_open (read_data = json.dumps (event))):
+          status, output = self.run_main ('-G')
+      self.assertEqual (status, 0)
+      messages = [line for line in server.sent if line.startswith ('PRIVMSG ')]
+      self.assertEqual (len (messages), 1)
+      self.assertIn ('author  QUIT', messages[0])
+      self.assertIn ('FAILURE', messages[0])
+      self.assertIn ('Fix the bot - https://example.invalid/commit', messages[0])
+      self.assertNotIn ('Details', messages[0])
+      server.sent.clear()
+      status, output = self.run_main ('plain message')
+      self.assertEqual (status, 0)
+      self.assertEqual ([line for line in server.sent if line.startswith ('PRIVMSG ')],
+                        ['PRIVMSG #test :plain message'])
+
+  def test_password_registration_never_logs_dummy_secret (self):
+    with self.mock_server() as (server, clock):
+      self.bot.args.quiet = False
+      self.bot.os.environ['IRCBOT_PASS'] = 'dummy-secret'
+      output = io.StringIO()
+      with contextlib.redirect_stdout (output), contextlib.redirect_stderr (output):
+        self.bot.run_session()
+      self.assertIn ('PASS dummy-secret', server.sent)
+      self.assertIn ('PASS <redacted>', output.getvalue())
+      self.assertNotIn ('dummy-secret', output.getvalue())
+
+  def test_ping_requires_its_own_pong_token (self):
+    for correct in (False, True):
+      with self.subTest (correct = correct), self.mock_server() as (server, clock):
+        self.bot.args.ping = True
+
+        def respond (line):
+          if line.startswith ('PING '):
+            server.queue (':mock PONG mock :wrong-token', ':mock NOTICE YYBOT :PONG pleasegetbacktome')
+            if not correct:
+              return
+          server.default_response (line)
+
+        server.respond = respond
+        if correct:
+          self.bot.run_session()
+          self.assertIn ('PRIVMSG #test :hello', server.sent)
+        else:
+          with self.assertRaises (TimeoutError):
+            self.bot.run_session()
+          self.assertFalse (any (line.startswith ('PRIVMSG ') for line in server.sent))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Reduces `ircbot.py` from 429 to 298 lines and limits it to the CI task: send one colored message to one joined IRC channel over TLS.

- Removes passwords, authentication, server selection, plaintext mode, channel listing, multi-message splitting, throttling, and post-send work.
- Keeps the existing mIRC colors. `-n` prints the same bounded message with ANSI colors and never opens a connection.
- Requests `echo-message` directly, which IRCv3 permits without a prior `CAP LS`.
- Treats `001` as successful registration and handles `432`, `433`, `465`, and errors for the active command immediately.
- Accepts an echo with the correct sender and target even when the server changed the message body, as required by the IRCv3 echo-message rules.
- Sends exactly one UTF-8-safe message of at most 400 bytes. It retries only before `PRIVMSG`; an uncertain send is never repeated.
- Creates and closes a fresh TLS socket for each connection attempt.

The 23 offline tests use fresh mock servers and a Python audit hook that rejects every real socket operation. They cover color preview and wire colors, GitHub event formatting, message bounds, injection prevention, registration, queued registration replies, server bans, server-modified echoes, immediate delivery errors, lost echoes, fresh retry sockets, fragmented UTF-8 replies, PING handling, and receive deadlines.

`Test-IrcBot` is the final job in `ci.yml`, waits for every real job, and is non-gating. `Ping-IRC` is skipped on pull requests. No Libera connection was made during development or testing.

Validation: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/workflows -p test_ircbot.py -v`; YAML parsing; `git diff --check`; local `-n` preview.

Only `.github/workflows/ircbot.py`, its test, and the CI invocation change.

<!-- devin-review-badge-begin -->
<a href="https://app.devin.ai/review/tim-janik/anklang/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

‒ 🤖 Codex, posting on behalf of @tim-janik
